### PR TITLE
Create consumer-rules.pro and fix crashes under R8 full mode

### DIFF
--- a/evervault-cages/consumer-rules.pro
+++ b/evervault-cages/consumer-rules.pro
@@ -1,0 +1,4 @@
+-keep class com.sun.jna.** { *; }
+-keep class * extends com.sun.jna.* { public *; }
+-keep class uniffi.bindings.** { *; }
+-dontwarn java.awt.**


### PR DESCRIPTION
# Why

Uniffi uses JNA which relies on reflection to read the field order for FFI as seen in [here](https://github.com/evervault/evervault-android/blob/main/evervault-cages/src/main/java/uniffi/bindings/bindings.kt#L35) and other places. This breaks under R8 full mode since it won't keep attributes if not matched by a rule.

# How

Keeps uniffi and related JNA packages. This is a broad net, it could be refined to only keep exactly what needed, but stops apps from crashing.