### PR TITLE
Amex bin is first 6 digits

### DIFF
--- a/evervault-inputs/src/main/java/com/evervault/sdk/input/model/PaymentCardDataValidation.kt
+++ b/evervault-inputs/src/main/java/com/evervault/sdk/input/model/PaymentCardDataValidation.kt
@@ -23,8 +23,8 @@ fun createPaymentCardData(number: String, cvc: String, expiry: String): PaymentC
     )
 
     if (validator.isValid) {
-        paymentCard.bin = number.take(8)
         paymentCard.lastFour = number.takeLast(4)
+        paymentCard.bin = if (cardType == CreditCardType.AMEX) number.take(6) else number.take(8)
     }
 
     val expiryParts = expiry.split("/")

--- a/evervault-inputs/src/main/java/com/evervault/sdk/input/ui/PaymentCardInput.kt
+++ b/evervault-inputs/src/main/java/com/evervault/sdk/input/ui/PaymentCardInput.kt
@@ -109,7 +109,7 @@ fun PaymentCardInput(
         updateCardData {
             copy(
                 card = card.copy(
-                    number = if (rawCardData.card.number.isBlank()) "" else Evervault.shared.encrypt(rawCardData.card.number) as? String ?: ""
+                    number = if (rawCardData.card.number.isBlank()) "" else Evervault.shared.encrypt(rawCardData.card.number.replace(" ", "")) as? String ?: ""
                 )
             )
         }


### PR DESCRIPTION
# Why
- Use first 6 digits for amex card bins
- Don't encrypt formatted card with inputs

# How
Describe how you've approached the problem