### PR TITLE
Eoin/etr 1290 update auto focus to allow editing previous fields

### DIFF
--- a/evervault-inputs/src/main/java/com/evervault/sdk/input/model/PaymentCardDataValidation.kt
+++ b/evervault-inputs/src/main/java/com/evervault/sdk/input/model/PaymentCardDataValidation.kt
@@ -3,6 +3,7 @@ package com.evervault.sdk.input.model
 import com.evervault.sdk.input.utils.CreditCardFormatter
 import com.evervault.sdk.input.utils.CreditCardValidator
 import com.evervault.sdk.input.utils.validNumberLength
+import java.util.Calendar
 
 internal val PaymentCardData.expiry: String get() = "${card.expMonth}/${card.expYear}"
 
@@ -36,7 +37,7 @@ fun createPaymentCardData(number: String, cvc: String, expiry: String): PaymentC
 
     val actualType = validator.actualType
     val isValid = actualType != null && validator.isValid && CreditCardValidator.isValidCvc(cvc, actualType)
-            && monthNumber != null && monthNumber in 1..12 && yearNumber != null
+            && isValidExpiry(monthNumber, yearNumber)
     val isPotentiallyValid = validator.isPotentiallyValid && (monthNumber == null || monthNumber in 1..12)
     val isEmpty = number.isEmpty()
 
@@ -53,6 +54,15 @@ fun createPaymentCardData(number: String, cvc: String, expiry: String): PaymentC
         isEmpty = isEmpty,
         error = error
     )
+}
+
+fun isValidExpiry(month: Int?, year: Int?): Boolean {
+    if (month == null || year == null) {
+        return false
+    }
+    val thisYearLastTwo: Int = Calendar.getInstance().get(Calendar.YEAR) % 100
+    val isValidMonthEntry = { m: Int -> m in 1 .. 12 }
+    return isValidMonthEntry(month) && year >= thisYearLastTwo
 }
 
 fun PaymentCardData.updateNumber(number: String): PaymentCardData {

--- a/evervault-inputs/src/main/java/com/evervault/sdk/input/ui/PaymentCardInput.kt
+++ b/evervault-inputs/src/main/java/com/evervault/sdk/input/ui/PaymentCardInput.kt
@@ -144,13 +144,6 @@ fun PaymentCardInput(
             text = rawCardData.card.number,
             selection = TextRange(cursorPosition)
         )
-
-        val validator = CreditCardValidator(creditCardNumber.value.text)
-        validator.actualType?.let { type ->
-            if (validator.string.length == type.validNumberLength.last()) {
-                expiryDateRequester.requestFocus()
-            }
-        }
     }
 
     LaunchedEffect(cvc.value) {
@@ -180,10 +173,6 @@ fun PaymentCardInput(
             text = formattedExpiry,
             selection = TextRange(cursorPosition)
         )
-
-        if (formattedExpiry.length == 5) {
-            cvcRequester.requestFocus()
-        }
     }
 
     LaunchedEffect(cardData) {

--- a/evervault-inputs/src/main/java/com/evervault/sdk/input/utils/CreditCardExpirationDateValidator.kt
+++ b/evervault-inputs/src/main/java/com/evervault/sdk/input/utils/CreditCardExpirationDateValidator.kt
@@ -1,0 +1,24 @@
+package com.evervault.sdk.input.utils
+
+import java.time.LocalDate
+import java.time.YearMonth
+
+internal object CreditCardExpirationDateValidator {
+
+    private val allowedMonths = 1..12
+
+    fun isValid(
+        expirationMonthNumber: String,
+        expirationYearLastTwoDigits: String
+    ): Boolean {
+        val monthNumber = expirationMonthNumber.toIntOrNull() ?: return false
+        if (monthNumber !in allowedMonths) return false
+        val yearInCentury = expirationYearLastTwoDigits.toIntOrNull() ?: return false
+        return getExpirationDate(monthNumber, yearInCentury) >= LocalDate.now()
+    }
+
+    private fun getExpirationDate(monthNumber: Int, lastTwoDigitsOfYear: Int): LocalDate {
+        val currentCentury = YearMonth.now().year / 100
+        return YearMonth.of(currentCentury * 100 + lastTwoDigitsOfYear, monthNumber).atEndOfMonth()
+    }
+}

--- a/evervault-inputs/src/test/java/com/evervault/sdk/input/utils/CreditCardExpirationDateValidatorTest.kt
+++ b/evervault-inputs/src/test/java/com/evervault/sdk/input/utils/CreditCardExpirationDateValidatorTest.kt
@@ -1,0 +1,55 @@
+package com.evervault.sdk.input.utils
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import org.junit.runners.Parameterized.Parameters
+import java.time.YearMonth
+
+@RunWith(Parameterized::class)
+internal class CreditCardExpirationDateValidatorTest(
+    private val expiryMonth: String,
+    private val expiryLastTwoDigitsOfYear: String,
+    private val expectedResult: Boolean,
+) {
+
+    companion object {
+
+        private val currentYearMonth = YearMonth.now()
+        private val currentYearLastTwoDigits = currentYearMonth.year % 100
+        private val previousYearLastTwoDigits = (currentYearLastTwoDigits - 1).toString()
+        private val nextYearLastTwoDigits = (currentYearLastTwoDigits + 1).toString()
+        private val previousMonth = (currentYearMonth.minusMonths(1)).monthValue.toString()
+        private val currentMonth = currentYearMonth.monthValue.toString()
+        private val nextMonth = (currentYearMonth.plusMonths(1)).monthValue.toString()
+
+        @JvmStatic
+        @Parameters(name = "Given expiryMonth = {0} and expiryLastTwoDigitsOfYear = {1} Then returns expectedResult = {2}")
+        fun data() = listOf(
+            arrayOf("", "", false),
+            arrayOf("", nextYearLastTwoDigits, false),
+            arrayOf(nextMonth, "", false),
+            arrayOf("A", "", false),
+            arrayOf("A", nextYearLastTwoDigits, false),
+            arrayOf("", "A", false),
+            arrayOf(nextMonth, "A", false),
+            arrayOf("23", nextYearLastTwoDigits, false),
+            arrayOf(nextMonth, nextYearLastTwoDigits, true),
+            arrayOf(nextMonth, previousYearLastTwoDigits, false),
+            arrayOf(previousMonth, previousYearLastTwoDigits, false),
+            arrayOf(previousMonth, currentYearLastTwoDigits.toString(), false),
+            arrayOf(previousMonth, nextYearLastTwoDigits, true),
+            arrayOf(currentMonth, previousYearLastTwoDigits, false),
+            arrayOf(currentMonth, nextYearLastTwoDigits, true),
+            arrayOf(currentMonth, nextYearLastTwoDigits, true)
+        )
+    }
+
+    @Test
+    fun validation() {
+        val actualResult =
+            CreditCardExpirationDateValidator.isValid(expiryMonth, expiryLastTwoDigitsOfYear)
+        assertEquals(expectedResult, actualResult)
+    }
+}

--- a/evervault-inputs/src/test/java/com/evervault/sdk/input/utils/CreditCardExpirationDateValidatorTest.kt
+++ b/evervault-inputs/src/test/java/com/evervault/sdk/input/utils/CreditCardExpirationDateValidatorTest.kt
@@ -23,33 +23,88 @@ internal class CreditCardExpirationDateValidatorTest(private val testData: TestD
         @JvmStatic
         @Parameters(name = "Given expiryMonth = {0} and expiryLastTwoDigitsOfYear = {1} Then returns expectedResult = {2}")
         fun data() = listOf(
-            TestData("", "", false),
-            TestData("", nextYearLastTwoDigits, false),
-            TestData(nextMonth, "", false),
-            TestData("A", "", false),
-            TestData("A", nextYearLastTwoDigits, false),
-            TestData("", "A", false),
-            TestData(nextMonth, "A", false),
-            TestData("23", nextYearLastTwoDigits, false),
-            TestData(previousMonth, previousYearLastTwoDigits, false),
-            TestData(previousMonth, currentYearLastTwoDigits.toString(), false),
-            TestData(previousMonth, nextYearLastTwoDigits, true),
-            TestData(currentMonth, previousYearLastTwoDigits, false),
-            TestData(currentMonth, currentYearLastTwoDigits.toString(), true),
-            TestData(currentMonth, nextYearLastTwoDigits, true),
-            TestData(nextMonth, previousYearLastTwoDigits, false),
-            TestData(nextMonth, currentYearLastTwoDigits.toString(), true),
-            TestData(nextMonth, nextYearLastTwoDigits, true)
+            TestData(expiryMonth = "", expiryLastTwoDigitsOfYear = "", expectedResult = false),
+            TestData(
+                expiryMonth = "",
+                expiryLastTwoDigitsOfYear = nextYearLastTwoDigits,
+                expectedResult = false
+            ),
+            TestData(
+                expiryMonth = nextMonth,
+                expiryLastTwoDigitsOfYear = "",
+                expectedResult = false
+            ),
+            TestData(expiryMonth = "A", expiryLastTwoDigitsOfYear = "", expectedResult = false),
+            TestData(
+                expiryMonth = "A",
+                expiryLastTwoDigitsOfYear = nextYearLastTwoDigits,
+                expectedResult = false
+            ),
+            TestData(expiryMonth = "", expiryLastTwoDigitsOfYear = "A", expectedResult = false),
+            TestData(
+                expiryMonth = nextMonth,
+                expiryLastTwoDigitsOfYear = "A",
+                expectedResult = false
+            ),
+            TestData(
+                expiryMonth = "23",
+                expiryLastTwoDigitsOfYear = nextYearLastTwoDigits,
+                expectedResult = false
+            ),
+            TestData(
+                expiryMonth = previousMonth,
+                expiryLastTwoDigitsOfYear = previousYearLastTwoDigits,
+                expectedResult = false
+            ),
+            TestData(
+                expiryMonth = previousMonth,
+                expiryLastTwoDigitsOfYear = currentYearLastTwoDigits.toString(),
+                expectedResult = false
+            ),
+            TestData(
+                expiryMonth = previousMonth,
+                expiryLastTwoDigitsOfYear = nextYearLastTwoDigits,
+                expectedResult = true
+            ),
+            TestData(
+                expiryMonth = currentMonth,
+                expiryLastTwoDigitsOfYear = previousYearLastTwoDigits,
+                expectedResult = false
+            ),
+            TestData(
+                expiryMonth = currentMonth,
+                expiryLastTwoDigitsOfYear = currentYearLastTwoDigits.toString(),
+                expectedResult = true
+            ),
+            TestData(
+                expiryMonth = currentMonth,
+                expiryLastTwoDigitsOfYear = nextYearLastTwoDigits,
+                expectedResult = true
+            ),
+            TestData(
+                expiryMonth = nextMonth,
+                expiryLastTwoDigitsOfYear = previousYearLastTwoDigits,
+                expectedResult = false
+            ),
+            TestData(
+                expiryMonth = nextMonth,
+                expiryLastTwoDigitsOfYear = currentYearLastTwoDigits.toString(),
+                expectedResult = true
+            ),
+            TestData(
+                expiryMonth = nextMonth,
+                expiryLastTwoDigitsOfYear = nextYearLastTwoDigits,
+                expectedResult = true
+            )
         )
     }
 
     @Test
     fun validation() {
-        val actualResult =
-            CreditCardExpirationDateValidator.isValid(
-                expirationMonthNumber = testData.expiryMonth,
-                expirationYearLastTwoDigits = testData.expiryLastTwoDigitsOfYear
-            )
+        val actualResult = CreditCardExpirationDateValidator.isValid(
+            expirationMonthNumber = testData.expiryMonth,
+            expirationYearLastTwoDigits = testData.expiryLastTwoDigitsOfYear
+        )
         assertEquals(testData.expectedResult, actualResult)
     }
 

--- a/evervault-inputs/src/test/java/com/evervault/sdk/input/utils/CreditCardExpirationDateValidatorTest.kt
+++ b/evervault-inputs/src/test/java/com/evervault/sdk/input/utils/CreditCardExpirationDateValidatorTest.kt
@@ -35,14 +35,15 @@ internal class CreditCardExpirationDateValidatorTest(
             arrayOf("", "A", false),
             arrayOf(nextMonth, "A", false),
             arrayOf("23", nextYearLastTwoDigits, false),
-            arrayOf(nextMonth, nextYearLastTwoDigits, true),
-            arrayOf(nextMonth, previousYearLastTwoDigits, false),
             arrayOf(previousMonth, previousYearLastTwoDigits, false),
             arrayOf(previousMonth, currentYearLastTwoDigits.toString(), false),
             arrayOf(previousMonth, nextYearLastTwoDigits, true),
             arrayOf(currentMonth, previousYearLastTwoDigits, false),
+            arrayOf(currentMonth, currentYearLastTwoDigits.toString(), true),
             arrayOf(currentMonth, nextYearLastTwoDigits, true),
-            arrayOf(currentMonth, nextYearLastTwoDigits, true)
+            arrayOf(nextMonth, previousYearLastTwoDigits, false),
+            arrayOf(nextMonth, currentYearLastTwoDigits.toString(), true),
+            arrayOf(nextMonth, nextYearLastTwoDigits, true)
         )
     }
 

--- a/evervault-inputs/src/test/java/com/evervault/sdk/input/utils/CreditCardExpirationDateValidatorTest.kt
+++ b/evervault-inputs/src/test/java/com/evervault/sdk/input/utils/CreditCardExpirationDateValidatorTest.kt
@@ -8,11 +8,7 @@ import org.junit.runners.Parameterized.Parameters
 import java.time.YearMonth
 
 @RunWith(Parameterized::class)
-internal class CreditCardExpirationDateValidatorTest(
-    private val expiryMonth: String,
-    private val expiryLastTwoDigitsOfYear: String,
-    private val expectedResult: Boolean,
-) {
+internal class CreditCardExpirationDateValidatorTest(private val testData: TestData) {
 
     companion object {
 
@@ -27,30 +23,39 @@ internal class CreditCardExpirationDateValidatorTest(
         @JvmStatic
         @Parameters(name = "Given expiryMonth = {0} and expiryLastTwoDigitsOfYear = {1} Then returns expectedResult = {2}")
         fun data() = listOf(
-            arrayOf("", "", false),
-            arrayOf("", nextYearLastTwoDigits, false),
-            arrayOf(nextMonth, "", false),
-            arrayOf("A", "", false),
-            arrayOf("A", nextYearLastTwoDigits, false),
-            arrayOf("", "A", false),
-            arrayOf(nextMonth, "A", false),
-            arrayOf("23", nextYearLastTwoDigits, false),
-            arrayOf(previousMonth, previousYearLastTwoDigits, false),
-            arrayOf(previousMonth, currentYearLastTwoDigits.toString(), false),
-            arrayOf(previousMonth, nextYearLastTwoDigits, true),
-            arrayOf(currentMonth, previousYearLastTwoDigits, false),
-            arrayOf(currentMonth, currentYearLastTwoDigits.toString(), true),
-            arrayOf(currentMonth, nextYearLastTwoDigits, true),
-            arrayOf(nextMonth, previousYearLastTwoDigits, false),
-            arrayOf(nextMonth, currentYearLastTwoDigits.toString(), true),
-            arrayOf(nextMonth, nextYearLastTwoDigits, true)
+            TestData("", "", false),
+            TestData("", nextYearLastTwoDigits, false),
+            TestData(nextMonth, "", false),
+            TestData("A", "", false),
+            TestData("A", nextYearLastTwoDigits, false),
+            TestData("", "A", false),
+            TestData(nextMonth, "A", false),
+            TestData("23", nextYearLastTwoDigits, false),
+            TestData(previousMonth, previousYearLastTwoDigits, false),
+            TestData(previousMonth, currentYearLastTwoDigits.toString(), false),
+            TestData(previousMonth, nextYearLastTwoDigits, true),
+            TestData(currentMonth, previousYearLastTwoDigits, false),
+            TestData(currentMonth, currentYearLastTwoDigits.toString(), true),
+            TestData(currentMonth, nextYearLastTwoDigits, true),
+            TestData(nextMonth, previousYearLastTwoDigits, false),
+            TestData(nextMonth, currentYearLastTwoDigits.toString(), true),
+            TestData(nextMonth, nextYearLastTwoDigits, true)
         )
     }
 
     @Test
     fun validation() {
         val actualResult =
-            CreditCardExpirationDateValidator.isValid(expiryMonth, expiryLastTwoDigitsOfYear)
-        assertEquals(expectedResult, actualResult)
+            CreditCardExpirationDateValidator.isValid(
+                expirationMonthNumber = testData.expiryMonth,
+                expirationYearLastTwoDigits = testData.expiryLastTwoDigitsOfYear
+            )
+        assertEquals(testData.expectedResult, actualResult)
     }
+
+    internal data class TestData(
+        val expiryMonth: String,
+        val expiryLastTwoDigitsOfYear: String,
+        val expectedResult: Boolean,
+    )
 }


### PR DESCRIPTION
# Why
Field focus will prevent users correcting invalid fields as revalidation occurs on focus and movement to the next field is initialized. Validation of the year is not strong enough.  

# How
- Check year is greater then current, refactor into a method
- Remove auto re-focus onto next field, allow user to initiate focus. 