### PR TITLE
Fixed the expiry date input field formatting and added input restrictions

### DIFF
--- a/evervault-inputs/src/main/java/com/evervault/sdk/input/utils/CreditCardExpirationDateCursorCalculator.kt
+++ b/evervault-inputs/src/main/java/com/evervault/sdk/input/utils/CreditCardExpirationDateCursorCalculator.kt
@@ -1,0 +1,34 @@
+package com.evervault.sdk.input.utils
+
+internal class CreditCardExpirationDateCursorCalculator {
+
+    internal fun newCursorPosition(
+        enteredText: String,
+        formattedText: String,
+        currentCursorPosition: Int,
+        lastCursorPosition: Int
+    ) = when {
+        formattedText.length > enteredText.length -> currentCursorPosition + 1 // Formatting the entered text added the separator, move the cursor to the year digit
+        formattedText.length == enteredText.length && lastCursorPosition == 1 && currentCursorPosition == 2 -> currentCursorPosition + 1 // Edited the second month digit and formatting succeeded, move the cursor to the year digit
+        enteredText.length > formattedText.length -> calculateNewCursorPositionAfterDigitsAdded(
+            formattedText = formattedText,
+            currentCursorPosition = currentCursorPosition,
+            lastCursorPosition = lastCursorPosition
+        )
+        else -> currentCursorPosition
+    }
+
+    private fun calculateNewCursorPositionAfterDigitsAdded(
+        formattedText: String,
+        currentCursorPosition: Int,
+        lastCursorPosition: Int
+    ) = when {
+        // Edited the month digit, but formatting failed (wrong digit),
+        // return cursor to the previous month digit to re-enter it again
+        currentCursorPosition < 3 && currentCursorPosition - lastCursorPosition == 1 && formattedText.length < 5 -> currentCursorPosition - 1
+        // The new digit was correct and formatting succeeded,
+        // move cursor to next position but do not move it after the year's second digit
+        currentCursorPosition in 2..3 -> currentCursorPosition + 1
+        else -> currentCursorPosition
+    }
+}

--- a/evervault-inputs/src/main/java/com/evervault/sdk/input/utils/CreditCardExpirationDateCursorCalculator.kt
+++ b/evervault-inputs/src/main/java/com/evervault/sdk/input/utils/CreditCardExpirationDateCursorCalculator.kt
@@ -9,7 +9,9 @@ internal class CreditCardExpirationDateCursorCalculator {
         lastCursorPosition: Int
     ) = when {
         formattedText.length > enteredText.length -> currentCursorPosition + 1 // Formatting the entered text added the separator, move the cursor to the year digit
-        formattedText.length == enteredText.length && lastCursorPosition == 1 && currentCursorPosition == 2 -> currentCursorPosition + 1 // Edited the second month digit and formatting succeeded, move the cursor to the year digit
+        formattedText.length == enteredText.length
+                && lastCursorPosition == 1
+                && currentCursorPosition == SEPARATOR_CURSOR_POSITION -> currentCursorPosition + 1 // Edited the second month digit and formatting succeeded, move the cursor to the year digit
         enteredText.length > formattedText.length -> calculateNewCursorPositionAfterDigitsAdded(
             formattedText = formattedText,
             currentCursorPosition = currentCursorPosition,
@@ -25,10 +27,18 @@ internal class CreditCardExpirationDateCursorCalculator {
     ) = when {
         // Edited the month digit, but formatting failed (wrong digit),
         // return cursor to the previous month digit to re-enter it again
-        currentCursorPosition < 3 && currentCursorPosition - lastCursorPosition == 1 && formattedText.length < 5 -> currentCursorPosition - 1
+        currentCursorPosition < SEPARATOR_CURSOR_POSITION + 1
+                && currentCursorPosition - lastCursorPosition == 1
+                && formattedText.length < INPUT_MAX_SIZE -> currentCursorPosition - 1
         // The new digit was correct and formatting succeeded,
         // move cursor to next position but do not move it after the year's second digit
-        currentCursorPosition in 2..3 -> currentCursorPosition + 1
+        currentCursorPosition in SEPARATOR_CURSOR_POSITION..SEPARATOR_CURSOR_POSITION + 1 -> currentCursorPosition + 1
         else -> currentCursorPosition
+    }
+
+    private companion object {
+
+        const val SEPARATOR_CURSOR_POSITION = 2
+        const val INPUT_MAX_SIZE = 5
     }
 }

--- a/evervault-inputs/src/main/java/com/evervault/sdk/input/utils/CreditCardExpirationDateFormatter.kt
+++ b/evervault-inputs/src/main/java/com/evervault/sdk/input/utils/CreditCardExpirationDateFormatter.kt
@@ -1,0 +1,73 @@
+package com.evervault.sdk.input.utils
+
+internal class CreditCardExpirationDateFormatter {
+
+    internal fun format(input: String): String {
+        val (month, year) = extractMonthAndYear(input)
+        val monthFormatted = formatMonth(month)
+
+        return when (monthFormatted.length) {
+            0 -> if (year.isNotBlank()) YEAR_PATTERN.format(year) else ""
+            1 -> if (year.isNotBlank()) {
+                MONTH_YEAR_PATTERN.format(monthFormatted, year)
+            } else {
+                monthFormatted
+            }
+            2 -> if (input.length > 2) {
+                MONTH_YEAR_PATTERN.format(monthFormatted, year)
+            } else {
+                monthFormatted + year
+            }
+            else -> ""
+        }
+    }
+
+    private fun extractMonthAndYear(input: String): Pair<String, String> =
+        if (input.contains("/")) {
+            val monthAndYearSubstrings = input.split("/")
+            var monthSubstring = monthAndYearSubstrings.getOrElse(0) { "" }
+            var yearSubstring = monthAndYearSubstrings.getOrElse(1) { "" }.take(2)
+            if (monthSubstring.length > 2) {
+                val monthDigitCarryOver = monthSubstring.substring(2).take(1)
+                yearSubstring = if (yearSubstring.length > 1) {
+                    (monthDigitCarryOver + yearSubstring[1]).take(2)
+                } else {
+                    monthDigitCarryOver
+                }
+                monthSubstring = monthSubstring.dropLast(1)
+            }
+            monthSubstring to yearSubstring
+        } else {
+            val monthSubstring = input.take(2)
+            val yearSubstring = if (input.length > 2) input.substring(2) else ""
+            monthSubstring to yearSubstring
+        }
+
+    private fun formatMonth(monthNumber: String): String {
+        val monthNumberDigits = monthNumber.toIntOrNull() ?: return ""
+        val firstMonthDigit = monthNumber.getOrNull(0)?.digitToIntOrNull()
+        val secondMonthDigit = monthNumber.getOrNull(1)?.digitToIntOrNull()
+
+        val firstMonthCharacter = if (firstMonthDigit in allowedMonthFirstDigits) {
+            firstMonthDigit.toString()
+        } else {
+            ""
+        }
+
+        val secondMonthCharacter = if (monthNumberDigits in allowedMonthNumbers) {
+            secondMonthDigit?.toString() ?: ""
+        } else {
+            ""
+        }
+
+        return firstMonthCharacter + secondMonthCharacter
+    }
+
+    private companion object {
+
+        const val MONTH_YEAR_PATTERN = "%s/%s"
+        const val YEAR_PATTERN = "/%s"
+        val allowedMonthFirstDigits = 0..1
+        val allowedMonthNumbers = 1..12
+    }
+}

--- a/evervault-inputs/src/main/java/com/evervault/sdk/input/utils/CreditCardExpirationDateFormatter.kt
+++ b/evervault-inputs/src/main/java/com/evervault/sdk/input/utils/CreditCardExpirationDateFormatter.kt
@@ -13,7 +13,7 @@ internal class CreditCardExpirationDateFormatter {
             } else {
                 monthFormatted
             }
-            2 -> if (input.length > 2) {
+            2 -> if (input.length > MAX_DIGITS_PER_NUMBER) {
                 MONTH_YEAR_PATTERN.format(monthFormatted, year)
             } else {
                 monthFormatted + year
@@ -23,14 +23,16 @@ internal class CreditCardExpirationDateFormatter {
     }
 
     private fun extractMonthAndYear(input: String): Pair<String, String> =
-        if (input.contains("/")) {
-            val monthAndYearSubstrings = input.split("/")
+        if (input.contains(DATE_SEPARATOR)) {
+            val monthAndYearSubstrings = input.split(DATE_SEPARATOR)
             var monthSubstring = monthAndYearSubstrings.getOrElse(0) { "" }
-            var yearSubstring = monthAndYearSubstrings.getOrElse(1) { "" }.take(2)
+            var yearSubstring = monthAndYearSubstrings
+                .getOrElse(1) { "" }
+                .take(MAX_DIGITS_PER_NUMBER)
             if (monthSubstring.length > 2) {
-                val monthDigitCarryOver = monthSubstring.substring(2).take(1)
+                val monthDigitCarryOver = monthSubstring.substring(MAX_DIGITS_PER_NUMBER).take(1)
                 yearSubstring = if (yearSubstring.length > 1) {
-                    (monthDigitCarryOver + yearSubstring[1]).take(2)
+                    (monthDigitCarryOver + yearSubstring[1]).take(MAX_DIGITS_PER_NUMBER)
                 } else {
                     monthDigitCarryOver
                 }
@@ -38,8 +40,12 @@ internal class CreditCardExpirationDateFormatter {
             }
             monthSubstring to yearSubstring
         } else {
-            val monthSubstring = input.take(2)
-            val yearSubstring = if (input.length > 2) input.substring(2) else ""
+            val monthSubstring = input.take(MAX_DIGITS_PER_NUMBER)
+            val yearSubstring = if (input.length > MAX_DIGITS_PER_NUMBER) {
+                input.substring(MAX_DIGITS_PER_NUMBER)
+            } else {
+                ""
+            }
             monthSubstring to yearSubstring
         }
 
@@ -65,8 +71,11 @@ internal class CreditCardExpirationDateFormatter {
 
     private companion object {
 
-        const val MONTH_YEAR_PATTERN = "%s/%s"
-        const val YEAR_PATTERN = "/%s"
+        const val MAX_DIGITS_PER_NUMBER = 2
+        const val DATE_SEPARATOR = "/"
+        const val MONTH_YEAR_PATTERN = "%s$DATE_SEPARATOR%s"
+        const val YEAR_PATTERN = "$DATE_SEPARATOR%s"
+
         val allowedMonthFirstDigits = 0..1
         val allowedMonthNumbers = 1..12
     }

--- a/evervault-inputs/src/main/java/com/evervault/sdk/input/utils/CreditCardFormatter.kt
+++ b/evervault-inputs/src/main/java/com/evervault/sdk/input/utils/CreditCardFormatter.kt
@@ -9,18 +9,22 @@ internal object CreditCardFormatter {
 
         var formattedString = ""
 
-        val groupLengths = if (CreditCardValidator(cardNumber).predictedType == CreditCardType.AMEX) {
-            listOf(4, 6, 5)
-        } else {
-            listOf(4, 4, 4, 4, 3)
-        }
+        val groupLengths =
+            if (CreditCardValidator(cardNumber).predictedType == CreditCardType.AMEX) {
+                listOf(4, 6, 5)
+            } else {
+                listOf(4, 4, 4, 4, 3)
+            }
 
         var currentIndex = 0
         for (length in groupLengths) {
             if (currentIndex >= formattedCardNumber.count()) {
                 break
             }
-            val group = formattedCardNumber.substring(currentIndex, minOf(currentIndex + length, formattedCardNumber.count()))
+            val group = formattedCardNumber.substring(
+                startIndex = currentIndex,
+                endIndex = minOf(currentIndex + length, formattedCardNumber.count())
+            )
             formattedString += "$group "
             currentIndex += length
         }
@@ -28,21 +32,5 @@ internal object CreditCardFormatter {
         formattedString = formattedString.dropLast(1) // Remove trailing space
 
         return formattedString
-    }
-
-    fun formatExpiryDate(value: String): String {
-        var formatted = value.take(5)
-        when (formatted.length) {
-            1, 2 -> {
-                formatted = formatted.filter { it.isDigit() }
-                val month = formatted.toIntOrNull() ?: return ""
-                if (formatted.length == 2) {
-                    formatted = "$formatted/"
-                } else if (month > 1) {
-                    formatted = "0$formatted/"
-                }
-            }
-        }
-        return formatted
     }
 }

--- a/evervault-inputs/src/test/java/com/evervault/sdk/input/utils/CreditCardExpirationDateCursorCalculatorTest.kt
+++ b/evervault-inputs/src/test/java/com/evervault/sdk/input/utils/CreditCardExpirationDateCursorCalculatorTest.kt
@@ -1,0 +1,104 @@
+package com.evervault.sdk.input.utils
+
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import org.junit.runners.Parameterized.Parameters
+
+@RunWith(Parameterized::class)
+internal class CreditCardExpirationDateCursorCalculatorTest(private val testData: TestData) {
+
+    companion object {
+
+        @JvmStatic
+        @Parameters(name = "testData = {0}")
+        fun data() = listOf(
+            TestData(
+                enteredText = "12/345",
+                formattedText = "12/34",
+                currentCursorPosition = 4,
+                lastCursorPosition = 3,
+                expectedResult = 4
+            ),
+            TestData(
+                enteredText = "12/345",
+                formattedText = "12/34",
+                currentCursorPosition = 3,
+                lastCursorPosition = 3,
+                expectedResult = 4
+            ),
+            TestData(
+                enteredText = "15/34",
+                formattedText = "1/34",
+                currentCursorPosition = 2,
+                lastCursorPosition = 1,
+                expectedResult = 1
+            ),
+            TestData(
+                enteredText = "5/34",
+                formattedText = "/34",
+                currentCursorPosition = 1,
+                lastCursorPosition = 0,
+                expectedResult = 0
+            ),
+            TestData(
+                enteredText = "5/34",
+                formattedText = "/34",
+                currentCursorPosition = 0,
+                lastCursorPosition = 1,
+                expectedResult = 0
+            ),
+            TestData(
+                enteredText = "1",
+                formattedText = "1",
+                currentCursorPosition = 1,
+                lastCursorPosition = 0,
+                expectedResult = 1
+            ),
+            TestData(
+                enteredText = "12",
+                formattedText = "12",
+                currentCursorPosition = 2,
+                lastCursorPosition = 1,
+                expectedResult = 3
+            ),
+            TestData(
+                enteredText = "12/",
+                formattedText = "12/",
+                currentCursorPosition = 3,
+                lastCursorPosition = 2,
+                expectedResult = 3
+            ),
+            TestData(
+                enteredText = "12/3",
+                formattedText = "12/3",
+                currentCursorPosition = 4,
+                lastCursorPosition = 3,
+                expectedResult = 4
+            )
+        )
+    }
+
+    private val classUnderTest = CreditCardExpirationDateCursorCalculator()
+
+    @Test
+    fun validation() {
+        val actualResult = classUnderTest.newCursorPosition(
+            enteredText = testData.enteredText,
+            formattedText = testData.formattedText,
+            currentCursorPosition = testData.currentCursorPosition,
+            lastCursorPosition = testData.lastCursorPosition
+        )
+
+        Assert.assertEquals(testData.expectedResult, actualResult)
+    }
+
+    internal data class TestData(
+        val enteredText: String,
+        val formattedText: String,
+        val currentCursorPosition: Int,
+        val lastCursorPosition: Int,
+        val expectedResult: Int
+    )
+}

--- a/evervault-inputs/src/test/java/com/evervault/sdk/input/utils/CreditCardExpirationDateFormatterTest.kt
+++ b/evervault-inputs/src/test/java/com/evervault/sdk/input/utils/CreditCardExpirationDateFormatterTest.kt
@@ -1,0 +1,84 @@
+package com.evervault.sdk.input.utils
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import org.junit.runners.Parameterized.Parameters
+
+@RunWith(Parameterized::class)
+internal class CreditCardExpirationDateFormatterTest(private val testData: TestData) {
+
+    companion object {
+
+        @JvmStatic
+        @Parameters(name = "testData = {0}")
+        fun data() = listOf(
+            TestData(input = "", expectedResult = ""),
+            TestData(input = "0", expectedResult = "0"),
+            TestData(input = "1", expectedResult = "1"),
+            TestData(input = "2", expectedResult = ""),
+            TestData(input = "3", expectedResult = ""),
+            TestData(input = "4", expectedResult = ""),
+            TestData(input = "5", expectedResult = ""),
+            TestData(input = "6", expectedResult = ""),
+            TestData(input = "7", expectedResult = ""),
+            TestData(input = "8", expectedResult = ""),
+            TestData(input = "9", expectedResult = ""),
+            TestData(input = "01", expectedResult = "01"),
+            TestData(input = "02", expectedResult = "02"),
+            TestData(input = "03", expectedResult = "03"),
+            TestData(input = "04", expectedResult = "04"),
+            TestData(input = "05", expectedResult = "05"),
+            TestData(input = "06", expectedResult = "06"),
+            TestData(input = "07", expectedResult = "07"),
+            TestData(input = "08", expectedResult = "08"),
+            TestData(input = "09", expectedResult = "09"),
+            TestData(input = "10", expectedResult = "10"),
+            TestData(input = "11", expectedResult = "11"),
+            TestData(input = "12", expectedResult = "12"),
+            TestData(input = "13", expectedResult = "1"),
+            TestData(input = "14", expectedResult = "1"),
+            TestData(input = "15", expectedResult = "1"),
+            TestData(input = "20", expectedResult = ""),
+            TestData(input = "21", expectedResult = ""),
+            TestData(input = "40", expectedResult = ""),
+            TestData(input = "80", expectedResult = ""),
+            TestData(input = "01/", expectedResult = "01/"),
+            TestData(input = "12/", expectedResult = "12/"),
+            TestData(input = "13/", expectedResult = "1"),
+            TestData(input = "19/", expectedResult = "1"),
+            TestData(input = "121", expectedResult = "12/1"),
+            TestData(input = "126", expectedResult = "12/6"),
+            TestData(input = "123/", expectedResult = "12/3"),
+            TestData(input = "129/", expectedResult = "12/9"),
+            TestData(input = "12/1", expectedResult = "12/1"),
+            TestData(input = "05/25", expectedResult = "05/25"),
+            TestData(input = "12/25", expectedResult = "12/25"),
+            TestData(input = "12/5", expectedResult = "12/5"),
+            TestData(input = "12/256", expectedResult = "12/25"),
+            TestData(input = "12/125", expectedResult = "12/12"),
+            TestData(input = "123/25", expectedResult = "12/35"),
+            TestData(input = "1225", expectedResult = "12/25"),
+            TestData(input = "1/25", expectedResult = "1/25"),
+            TestData(input = "15/25", expectedResult = "1/25"),
+            TestData(input = "5/25", expectedResult = "/25"),
+            TestData(input = "/25", expectedResult = "/25"),
+            TestData(input = "25", expectedResult = "")
+        )
+    }
+
+    private val classUnderTest = CreditCardExpirationDateFormatter()
+
+    @Test
+    fun validation() {
+        val actualResult = classUnderTest.format(testData.input)
+
+        assertEquals(testData.expectedResult, actualResult)
+    }
+
+    data class TestData(
+        val input: String,
+        val expectedResult: String
+    )
+}


### PR DESCRIPTION
# Why
The expiry text input almost did not have any validation. When we enabled the possibility to edit it, the user experience was unsatisfactory (the validation did not work properly and the user was seeing some bizarre formatting issues). In this PR we have refactored the formatting and cursor repositioning logic, so the user now has a much natural editing flow with all edge cases covered.

The related fix for the unavailability to edit the expiry date input field is [here](https://github.com/evervault/evervault-android/pull/16).

# How
Refactored and extracted the input field formatting and cursor repositioning logic to separate classes to make the code more scalable, maintainable, and testable, and created `UnitTests` for them. The new logic covers all the edge cases (here are some of them):
1. Editing the month's first digit does not allow to enter anything but 0 and 1
2. Editing the month's second digit (the logic is tied with the first digit, so the user is not allowed to enter invalid digits) and the cursor does not move until we enter a correct number
3. Carrying over the newly entered digits to the new places
4. Automatically adding the separator
5. Editing any current digit formats the date correctly and places the cursor in the expected position