### PR TITLE
Bump versions for release 1.3

### DIFF
--- a/evervault-cages/build.gradle.kts
+++ b/evervault-cages/build.gradle.kts
@@ -80,7 +80,7 @@ publishing {
         register<MavenPublication>("release") {
             groupId = "com.evervault.sdk"
             artifactId = "evervault-cages"
-            version = "1.2"
+            version = "1.3"
 
             afterEvaluate {
                 from(components["release"])

--- a/evervault-inputs/build.gradle.kts
+++ b/evervault-inputs/build.gradle.kts
@@ -78,7 +78,7 @@ publishing {
         register<MavenPublication>("release") {
             groupId = "com.evervault.sdk"
             artifactId = "evervault-inputs"
-            version = "1.2"
+            version = "1.3"
 
             afterEvaluate {
                 from(components["release"])


### PR DESCRIPTION
# Release
#15 Cages GA Attestation

# Changeset
v1.3
feat: Cages GA attestation. Deprecate `trustManager` and introduce `cagesTrustManager` for attestation with trusted TLS certificates