### PR TITLE
Eoin/add version to evervault common

### DIFF
--- a/.changeset/shaggy-oranges-obey.md
+++ b/.changeset/shaggy-oranges-obey.md
@@ -1,0 +1,5 @@
+---
+"evervault-android": patch
+---
+
+Adding version to evervault-common to fix version dependency issue.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
                   print;
               }
             ' CHANGELOG.md)
-            gh release create v$COMMIT_TAG -t "$COMMIT_TAG" -n "$CHANGELOG"
+            gh release create $COMMIT_TAG -t "$COMMIT_TAG" -n "$CHANGELOG"
             ./generate_gradle_properties.bash ${{ github.workspace }}
             ./gradlew publishToSonatype
           else

--- a/evervault-cages/build.gradle.kts
+++ b/evervault-cages/build.gradle.kts
@@ -64,7 +64,6 @@ android {
 
 dependencies {
     implementation("com.evervault.sdk:evervault-core:1.0")
-
     implementation("androidx.core:core-ktx:1.8.0")
     implementation(platform("org.jetbrains.kotlin:kotlin-bom:1.8.0"))
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.3.1")

--- a/evervault-common/build.gradle.kts
+++ b/evervault-common/build.gradle.kts
@@ -7,10 +7,9 @@ plugins {
 android {
     namespace = "com.evervault.sdk.common"
     compileSdk = 33
-
+    version = "0.1.0"
     defaultConfig {
         minSdk = 26
-
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")
     }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "1.6.0",
   "scripts": {
-    "version": "npm run changeset && PACKAGE_VERSION=$(node -p \"require('./package.json').version\") && sed -i \"/VERSION_NAME=/ s/=.*/=$PACKAGE_VERSION/\" version.properties"
+    "version": "changeset version && PACKAGE_VERSION=$(node -p \"require('./package.json').version\") && sed -i \"/VERSION_NAME=/ s/=.*/=$PACKAGE_VERSION/\" version.properties"
   },
   "devDependencies": {
     "@changesets/cli": "^2.26.2"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -9,7 +9,7 @@ pluginManagement {
 
 rootProject.name = "evervault-android"
 include(":sampleapplication")
-include(":evervault-inputs")
+include(":evervault-inputs", "")
 include(":evervault-cages")
 include(":evervault-common")
 include(":evervault-common-e2e")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -9,7 +9,7 @@ pluginManagement {
 
 rootProject.name = "evervault-android"
 include(":sampleapplication")
-include(":evervault-inputs", "")
+include(":evervault-inputs")
 include(":evervault-cages")
 include(":evervault-common")
 include(":evervault-common-e2e")


### PR DESCRIPTION
# Why
Not adding a version to the `evervault-common` module references an unspecified build version in the generated `pom.xml`. The github tag and release contains a extra `v`

# How
- Add version to the `build.kts` for `evervault-common`
- Remove `v` from CI release