### PR TITLE
revert to using evervault-core for inputs

### DIFF
--- a/.changeset/breezy-elephants-mix.md
+++ b/.changeset/breezy-elephants-mix.md
@@ -1,0 +1,5 @@
+---
+"evervault-android": patch
+---
+
+revert to using external evervault-core library

--- a/evervault-inputs/build.gradle.kts
+++ b/evervault-inputs/build.gradle.kts
@@ -63,7 +63,7 @@ android {
 }
 
 dependencies {
-    implementation(project(":evervault-common"))
+    implementation("com.evervault.sdk:evervault-core:1.1")
     implementation("androidx.core:core-ktx:1.12.0")
     implementation(platform("org.jetbrains.kotlin:kotlin-bom:1.8.0"))
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.6.2")

--- a/evervault-inputs/src/main/java/com/evervault/sdk/input/ui/PaymentCardInput.kt
+++ b/evervault-inputs/src/main/java/com/evervault/sdk/input/ui/PaymentCardInput.kt
@@ -15,7 +15,7 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.TextFieldValue
-import com.evervault.sdk.common.Evervault
+import com.evervault.sdk.Evervault
 import com.evervault.sdk.input.model.CreditCardType
 import com.evervault.sdk.input.model.PaymentCardData
 import com.evervault.sdk.input.model.PaymentCardError

--- a/sampleapplication/build.gradle.kts
+++ b/sampleapplication/build.gradle.kts
@@ -49,7 +49,7 @@ android {
 dependencies {
     implementation(project(":evervault-inputs"))
     implementation(project(":evervault-cages"))
-    implementation(project(":evervault-common"))
+    implementation("com.evervault.sdk:evervault-core:1.1")
     implementation("androidx.core:core-ktx:1.8.0")
     implementation(platform("org.jetbrains.kotlin:kotlin-bom:1.8.0"))
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.3.1")

--- a/sampleapplication/src/main/java/com/evervault/sampleapplication/MainActivity.kt
+++ b/sampleapplication/src/main/java/com/evervault/sampleapplication/MainActivity.kt
@@ -15,8 +15,8 @@ import androidx.compose.ui.Modifier
 import androidx.navigation.compose.rememberNavController
 import com.evervault.sampleapplication.navigation.NavigationGraph
 import com.evervault.sampleapplication.ui.theme.EvervaultandroidTheme
-import com.evervault.sdk.common.CustomConfig
-import com.evervault.sdk.common.Evervault
+import com.evervault.sdk.CustomConfig
+import com.evervault.sdk.Evervault
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/sampleapplication/src/main/java/com/evervault/sampleapplication/ui/views/BasicEncryptionView.kt
+++ b/sampleapplication/src/main/java/com/evervault/sampleapplication/ui/views/BasicEncryptionView.kt
@@ -10,7 +10,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import com.evervault.sdk.common.Evervault
+import com.evervault.sdk.Evervault
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable

--- a/sampleapplication/src/main/java/com/evervault/sampleapplication/ui/views/FileEncryptionView.kt
+++ b/sampleapplication/src/main/java/com/evervault/sampleapplication/ui/views/FileEncryptionView.kt
@@ -23,7 +23,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import coil.compose.rememberAsyncImagePainter
-import com.evervault.sdk.common.Evervault
+import com.evervault.sdk.Evervault
 import kotlin.io.encoding.Base64
 import kotlin.io.encoding.ExperimentalEncodingApi
 


### PR DESCRIPTION
# Why
Using an internal module is causing the pom to generate a reference to an external module which fails to build.

# How
- revert to using external dependency `evervault-core`.