### PR TITLE
Add CagePCRManager to allow for pulling PCRs from an external provider

### DIFF
--- a/.changeset/three-pandas-judge.md
+++ b/.changeset/three-pandas-judge.md
@@ -1,0 +1,5 @@
+---
+"evervault-android": minor
+---
+
+Implement a PCR cache manager for working with attestable cages. This feature allows for the updating of a list of PCRs from an external callback url

--- a/evervault-cages/build.gradle.kts
+++ b/evervault-cages/build.gradle.kts
@@ -71,12 +71,13 @@ dependencies {
     implementation("net.java.dev.jna:jna:5.7.0@aar")
     implementation("com.squareup.okhttp3:okhttp:4.11.0")
     implementation("junit:junit:4.12")
-
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.3.2")
     implementation("com.squareup.okhttp3:okhttp:4.9.3")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.2")
-
     testImplementation("junit:junit:4.13.2")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3")
+    testImplementation("org.mockito.kotlin:mockito-kotlin:5.0.0")
+    testImplementation("com.squareup.retrofit2:converter-gson:2.9.0")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
 }

--- a/evervault-cages/src/main/java/com/evervault/sdk/cages/AttestationData.kt
+++ b/evervault-cages/src/main/java/com/evervault/sdk/cages/AttestationData.kt
@@ -1,10 +1,15 @@
 package com.evervault.sdk.cages
 
+private const val DEFAULT_CALLBACK_DURATION: Long = 300000 // 5 Minutes
+
 data class AttestationData(
     val cageName: String,
-    val pcrs: List<PCRs>
+    var pcrs: List<PCRs>,
+    val pcrCallback: PcrCallback? = null,
+    val callbackInterval: Long = DEFAULT_CALLBACK_DURATION
 ) {
     constructor(cageName: String, vararg pcrs: PCRs) : this(cageName, pcrs.toList())
+    constructor(cageName: String, pcrCallback: PcrCallback? = null, callbackInterval: Long = DEFAULT_CALLBACK_DURATION) : this(cageName, emptyList(), pcrCallback, callbackInterval)
 }
 
 data class PCRs(

--- a/evervault-cages/src/main/java/com/evervault/sdk/cages/AttestationData.kt
+++ b/evervault-cages/src/main/java/com/evervault/sdk/cages/AttestationData.kt
@@ -2,6 +2,8 @@ package com.evervault.sdk.cages
 
 private const val DEFAULT_CALLBACK_DURATION: Long = 300000 // 5 Minutes
 
+typealias PcrCallback = () -> List<PCRs>
+
 data class AttestationData(
     val cageName: String,
     var pcrs: List<PCRs>,

--- a/evervault-cages/src/main/java/com/evervault/sdk/cages/AttestationDocCache.kt
+++ b/evervault-cages/src/main/java/com/evervault/sdk/cages/AttestationDocCache.kt
@@ -18,6 +18,7 @@ import java.lang.Exception
 data class AttestationDoc(
     @SerialName("attestation_doc") val attestationDoc: String,
 )
+@OptIn(DelicateCoroutinesApi::class)
 class AttestationDocCache(private val cageName: String, private val appUuid: String) {
     private var attestationDoc: ByteArray = ByteArray(0)
     private val lock = ReentrantReadWriteLock()
@@ -25,7 +26,7 @@ class AttestationDocCache(private val cageName: String, private val appUuid: Str
     init {
         storeDoc(2)
         GlobalScope.launch(Dispatchers.IO) {
-            poll(7200)
+            poll(300)
         }
     }
 
@@ -33,7 +34,7 @@ class AttestationDocCache(private val cageName: String, private val appUuid: Str
         if(retries >= 0) {
             try {
                 val url =
-                    "https://${cageName}.${appUuid}.cage.evervault.com/.well-known/attestation"
+                    "https://${cageName}.${appUuid}.cage.evervault.dev/.well-known/attestation"
                 val response = getDocFromCage(url)
                 val decodedDoc = Base64.decode(response.attestationDoc, Base64.DEFAULT)
                 set(decodedDoc)

--- a/evervault-cages/src/main/java/com/evervault/sdk/cages/AttestationDocCache.kt
+++ b/evervault-cages/src/main/java/com/evervault/sdk/cages/AttestationDocCache.kt
@@ -34,7 +34,7 @@ class AttestationDocCache(private val cageName: String, private val appUuid: Str
         if(retries >= 0) {
             try {
                 val url =
-                    "https://${cageName}.${appUuid}.cage.evervault.dev/.well-known/attestation"
+                    "https://${cageName}.${appUuid}.cage.evervault.com/.well-known/attestation"
                 val response = getDocFromCage(url)
                 val decodedDoc = Base64.decode(response.attestationDoc, Base64.DEFAULT)
                 set(decodedDoc)

--- a/evervault-cages/src/main/java/com/evervault/sdk/cages/CagePcrManager.kt
+++ b/evervault-cages/src/main/java/com/evervault/sdk/cages/CagePcrManager.kt
@@ -12,8 +12,6 @@ import kotlin.Exception
 import kotlin.concurrent.read
 import kotlin.concurrent.write
 
-typealias PcrCallback = () -> List<PCRs>
-
 class PCRCallbackError(message: String): Exception(message)
 
 private data class PCRCallbackCache(

--- a/evervault-cages/src/main/java/com/evervault/sdk/cages/CagePcrManager.kt
+++ b/evervault-cages/src/main/java/com/evervault/sdk/cages/CagePcrManager.kt
@@ -4,7 +4,6 @@ import android.content.ContentValues.TAG
 import android.util.Log
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import java.util.concurrent.ConcurrentHashMap
@@ -25,8 +24,8 @@ private data class PCRCallbackCache(
     val pcrs: List<PCRs>?
         get() = lock.read { _pcrs }
 
-    fun setPcrs(newPcrs: List<PCRs>) {
-        lock.write { _pcrs = newPcrs }
+    fun setPCRs(newPCRs: List<PCRs>) {
+        lock.write { _pcrs = newPCRs }
     }
 }
 
@@ -64,7 +63,7 @@ class CagePcrManager private constructor(callbackDuration: Long){
                         Log.w(TAG, "Invoking cached PCR callback for Cage $k")
                         try {
                             cache.callback.invoke().also {
-                                cache.setPcrs(it)
+                                cache.setPCRs(it)
                             }
                         } catch (e: Exception) {
                             Log.e(TAG, "Error invoking PCR callback for Cage $k ${e.message!!}")
@@ -83,7 +82,7 @@ class CagePcrManager private constructor(callbackDuration: Long){
                 callback = pcrCallback
             )
             try {
-                cacheManager[cageName]?.setPcrs(invokeCallback(pcrCallback))
+                cacheManager[cageName]?.setPCRs(invokeCallback(pcrCallback))
             } catch (e: Exception) {
                 e.message?.let {
                     throw PCRCallbackError(e.message!!)
@@ -101,6 +100,6 @@ class CagePcrManager private constructor(callbackDuration: Long){
     }
 
     fun getPCRs(cageName: String): List<PCRs> {
-        return cacheManager[cageName]?.pcrs!!
+        return cacheManager[cageName]?.pcrs ?: throw PCRCallbackError("Unable to retrieve PCRs from empty cache")
     }
 }

--- a/evervault-cages/src/main/java/com/evervault/sdk/cages/CagePcrManager.kt
+++ b/evervault-cages/src/main/java/com/evervault/sdk/cages/CagePcrManager.kt
@@ -1,0 +1,106 @@
+package com.evervault.sdk.cages
+
+import android.content.ContentValues.TAG
+import android.util.Log
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.locks.ReentrantReadWriteLock
+import kotlin.Exception
+import kotlin.concurrent.read
+import kotlin.concurrent.write
+
+typealias PcrCallback = () -> List<PCRs>
+
+class PCRCallbackError(message: String): Exception(message)
+
+private data class PCRCallbackCache(
+    private var _pcrs: List<PCRs>? = null,
+    val callback: PcrCallback,
+    private val lock: ReentrantReadWriteLock = ReentrantReadWriteLock()
+) {
+    val pcrs: List<PCRs>?
+        get() = lock.read { _pcrs }
+
+    fun setPcrs(newPcrs: List<PCRs>) {
+        lock.write { _pcrs = newPcrs }
+    }
+}
+
+class CagePcrManager private constructor(callbackDuration: Long){
+    private var cacheManager: ConcurrentHashMap<String, PCRCallbackCache> = ConcurrentHashMap(50)
+    private val scope = CoroutineScope(Dispatchers.IO)
+    private var active: Boolean = false
+
+    init {
+        Log.w(TAG, "Starting CagePcrManager with interval duration $callbackDuration")
+        startPcrManager(callbackDuration)
+        active = true
+    }
+
+    companion object {
+        @Volatile
+        private var instance: CagePcrManager? = null
+
+        fun getInstance(callbackDuration: Long) = instance ?: synchronized(this) {
+            instance ?: CagePcrManager(callbackDuration).also {
+                instance = it
+            }
+        }
+    }
+
+    fun invoke(cageName: String, pcrCallback: PcrCallback) {
+        this.updateCacheManager(cageName, pcrCallback)
+    }
+
+    private fun startPcrManager(duration: Long) {
+        if (!active) {
+            scope.launch {
+                while (true) {
+                    cacheManager.forEach { (k, cache) ->
+                        Log.w(TAG, "Invoking cached PCR callback for Cage $k")
+                        try {
+                            cache.callback.invoke().also {
+                                cache.setPcrs(it)
+                            }
+                        } catch (e: Exception) {
+                            Log.e(TAG, "Error invoking PCR callback for Cage $k ${e.message!!}")
+                        }
+                    }
+                    delay(duration)
+                }
+            }
+        }
+    }
+
+    private fun updateCacheManager(cageName: String, pcrCallback: PcrCallback) {
+        if(this.cacheManager[cageName] == null) {
+            Log.w(TAG, "Updating CagePCRManager cache for Cage $cageName")
+            this.cacheManager[cageName] = PCRCallbackCache(
+                callback = pcrCallback
+            )
+            try {
+                cacheManager[cageName]?.setPcrs(invokeCallback(pcrCallback))
+            } catch (e: Exception) {
+                e.message?.let {
+                    throw PCRCallbackError(e.message!!)
+                }
+            }
+        }
+    }
+
+    private fun invokeCallback(callback: PcrCallback): List<PCRs> {
+        try {
+            return callback.invoke()
+        } catch (e: Exception) {
+            throw PCRCallbackError(e.message!!)
+        }
+    }
+
+    fun getPCRs(cageName: String): List<PCRs> {
+        return cacheManager[cageName]?.pcrs!!
+    }
+}

--- a/evervault-cages/src/test/java/android/util/Log.java
+++ b/evervault-cages/src/test/java/android/util/Log.java
@@ -1,0 +1,25 @@
+package android.util;
+
+// Overrides default Android Logger for tests
+public class Log {
+    public static int d(String tag, String msg) {
+        System.out.println("DEBUG: " + tag + ": " + msg);
+        return 0;
+    }
+
+    public static int i(String tag, String msg) {
+        System.out.println("INFO: " + tag + ": " + msg);
+        return 0;
+    }
+
+    public static int w(String tag, String msg) {
+        System.out.println("WARN: " + tag + ": " + msg);
+        return 0;
+    }
+
+    public static int e(String tag, String msg) {
+        System.out.println("ERROR: " + tag + ": " + msg);
+        return 0;
+    }
+
+}

--- a/evervault-cages/src/test/java/com/evervault/sdk/cages/AttestationTrustManagerTest.kt
+++ b/evervault-cages/src/test/java/com/evervault/sdk/cages/AttestationTrustManagerTest.kt
@@ -1,0 +1,66 @@
+package com.evervault.sdk.cages
+
+import AttestationDocCache
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.Mockito
+import org.mockito.MockitoAnnotations
+import org.mockito.kotlin.spy
+import org.mockito.kotlin.times
+import java.security.cert.CertificateException
+import java.security.cert.X509Certificate
+
+class AttestationTrustManagerTest {
+
+    @Mock
+    private lateinit var attestationDocCache: AttestationDocCache
+    private lateinit var attestationTrustManager: AttestationTrustManagerGA
+    private lateinit var attestationData: AttestationData
+
+    val cageName = "test-cage"
+    val appUuid ="app-uuid"
+    val PCRs = PCRs("0000", "1111", "2222", "3333")
+    val attestationDoc = ByteArray(0)
+    val attestCageCallback: AttestCageCallback = { _, _, _ ->
+        true
+    }
+    @Before
+    fun setup() {
+        MockitoAnnotations.openMocks(this)
+        attestationData = AttestationData(cageName, PCRs)
+        attestationTrustManager = AttestationTrustManagerGA(attestationData, attestationDocCache, attestCageCallback)
+    }
+
+    @Test(expected = CertificateException::class)
+    fun `throws expection when certificate chain isn't present`() {
+        attestationTrustManager.checkServerTrusted(emptyArray(), null)
+    }
+
+    @Test
+    fun `no excpetion thrown when setting implicit PCRs`() {
+        val mockCert = Mockito.mock(X509Certificate::class.java)
+        Mockito.`when`(mockCert.encoded).thenReturn(ByteArray(1))
+        val mockCertArray: Array<X509Certificate> = arrayOf(mockCert)
+        Mockito.`when`(attestationDocCache.get()).thenReturn(attestationDoc)
+
+        attestationTrustManager.checkServerTrusted(mockCertArray, null)
+    }
+
+    @Test
+    fun `passing pcr callback doesn't use implicit PCRs`() {
+        val PCRs = listOf(PCRs("0000", "1111", "2222", "3333"))
+        val spyPCRs = spy<PcrCallback>()
+        Mockito.`when`(spyPCRs.invoke()).thenReturn(PCRs)
+        attestationData = AttestationData(cageName, spyPCRs)
+        attestationTrustManager = AttestationTrustManagerGA(attestationData, attestationDocCache, attestCageCallback)
+        val mockCert = Mockito.mock(X509Certificate::class.java)
+        Mockito.`when`(mockCert.encoded).thenReturn(ByteArray(1))
+        val mockCertArray: Array<X509Certificate> = arrayOf(mockCert)
+        Mockito.`when`(attestationDocCache.get()).thenReturn(attestationDoc)
+
+        attestationTrustManager.checkServerTrusted(mockCertArray, null)
+
+        Mockito.verify(spyPCRs, times(1)).invoke()
+    }
+}

--- a/evervault-cages/src/test/java/com/evervault/sdk/cages/CagePcrManagerTest.kt
+++ b/evervault-cages/src/test/java/com/evervault/sdk/cages/CagePcrManagerTest.kt
@@ -92,6 +92,12 @@ class CagePcrManagerTest {
         manager.invoke(cageName, throwingPcrCallback)
     }
 
+    @Test(expected = PCRCallbackError::class)
+    fun `accessing empty cache throws error`() {
+        val cageName = "fifthCage";
+        manager.getPCRs(cageName)
+    }
+
     private fun createMockHttpClient(responsePCRs: List<PCRs>): OkHttpClient {
         val mockClient = mock(OkHttpClient::class.java)
         val mockCall = mock(Call::class.java)

--- a/evervault-cages/src/test/java/com/evervault/sdk/cages/CagePcrManagerTest.kt
+++ b/evervault-cages/src/test/java/com/evervault/sdk/cages/CagePcrManagerTest.kt
@@ -1,0 +1,115 @@
+import com.evervault.sdk.cages.CagePcrManager
+import com.evervault.sdk.cages.PCRCallbackError
+import com.evervault.sdk.cages.PCRs
+import com.evervault.sdk.cages.PcrCallback
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import okhttp3.Call
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.ResponseBody
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Before
+import org.junit.Test
+import org.junit.Assert.*
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.anyOrNull
+
+@ExperimentalCoroutinesApi
+class CagePcrManagerTest {
+    private val testCageName = "testCage"
+    private lateinit var testPcrCallback: PcrCallback
+    private lateinit var manager: CagePcrManager
+
+    @Before
+    fun setUp() {
+        testPcrCallback = { listOf(PCRs("0000", "1111", "2222", "3333")) }
+
+        manager = CagePcrManager.getInstance(10000000)
+    }
+
+    @Test
+    fun `when startPcrManager is invoked, it returns a list of PCRs`() = runTest {
+        manager.invoke(testCageName, testPcrCallback)
+
+        val pcrsResponse = manager.getPCRs(testCageName)
+
+        assertNotNull(pcrsResponse)
+        assertEquals(1, pcrsResponse.size)
+        assertEquals("0000", pcrsResponse[0].pcr0)
+    }
+
+    @Test
+    fun `setting pcrs for a second cage returns different pcrs`() = runTest {
+        val cageName = "secondCage"
+        val testPcrCallback = { listOf(PCRs("3333", "1111", "2222", "3333")) }
+        manager.invoke(cageName, testPcrCallback)
+
+        val pcrsResponse = manager.getPCRs(cageName)
+
+        assertEquals("3333", pcrsResponse[0].pcr0)
+    }
+
+    @Test
+    fun `calling external PCR service sets PCRs`() = runTest {
+        val cageName = "thirdCages"
+        val testPCRs = listOf(PCRs("4444", "1111", "2222", "3333"))
+        val httpClient = createMockHttpClient(testPCRs)
+        val testPcrCallback = {
+            val pcrRequest = Request.Builder()
+                .url("https://pcrcallback.com")
+                .header("content-type", "application/json")
+                .get()
+                .build()
+            val pcrResponse: ResponseBody? = httpClient.newCall(pcrRequest).execute().body
+            if (pcrResponse !== null) {
+                val type = object : TypeToken<List<PCRs>>() {}.type
+                val responseMap: List<PCRs> = Gson().fromJson(pcrResponse.string(), type)
+                responseMap
+            } else {
+                throw Error("Response body is null")
+            }
+        }
+        manager.invoke(cageName, testPcrCallback)
+
+        val pcrsResponse = manager.getPCRs(cageName)
+
+        assertEquals("4444", pcrsResponse[0].pcr0)
+    }
+
+    @Test(expected = PCRCallbackError::class)
+    fun `PCR callback throws exception`() = runTest {
+        val cageName = "fourthCage"
+        val throwingPcrCallback = {
+            throw Exception("Error from PCR callback")
+        }
+        manager.invoke(cageName, throwingPcrCallback)
+    }
+
+    private fun createMockHttpClient(responsePCRs: List<PCRs>): OkHttpClient {
+        val mockClient = mock(OkHttpClient::class.java)
+        val mockCall = mock(Call::class.java)
+        val gson = Gson()
+        val responsePCRsJson = gson.toJson(responsePCRs)
+
+        val mockResponse = Response.Builder()
+            .request(Request.Builder().url("https://pcrCallback.com").build())
+            .protocol(Protocol.HTTP_1_1)
+            .code(200) // HTTP status code
+            .message("OK")
+            .body(responsePCRsJson.toResponseBody("application/json; charset=utf-8".toMediaType()))
+            .build()
+
+        `when`(mockClient.newCall(anyOrNull())).thenReturn(mockCall)
+        `when`(mockCall.execute()).thenReturn(mockResponse)
+
+        return mockClient
+    }
+
+}

--- a/sampleapplication/build.gradle.kts
+++ b/sampleapplication/build.gradle.kts
@@ -18,6 +18,10 @@ android {
         vectorDrawables {
             useSupportLibrary = true
         }
+
+        buildConfigField("String", "CAGE_UUID", "\"hello-cage\"")
+        buildConfigField("String", "APP_UUID", "\"app-5e6b75800e28\"")
+        buildConfigField("String", "PCR_CALLBACK_URL", "\"https://blackhole.posterior.io/0xljnh\"")
     }
 
     buildTypes {
@@ -25,6 +29,9 @@ android {
             isMinifyEnabled = false
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
         }
+    }
+    buildFeatures {
+        buildConfig = true
     }
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8

--- a/sampleapplication/src/main/java/com/evervault/sampleapplication/ui/views/CageView.kt
+++ b/sampleapplication/src/main/java/com/evervault/sampleapplication/ui/views/CageView.kt
@@ -29,25 +29,22 @@ import java.io.IOException
 @Composable
 fun CageView() {
 
-    val cageName = "staging-synthetic-cage"
-    val appId = "app-1bba8ba15402"
+    val cageName = "hello-cage"
+    val appId = "app-5e6b75800e28"
 
     var responseText: String? by remember { mutableStateOf(null) }
 
     LaunchedEffect(Unit) {
         withContext(Dispatchers.IO) {
-            val url = "https://$cageName.$appId.cage.evervault.dev/echo"
+            val url = "https://$cageName.$appId.cage.evervault.com/compute"
             val pcrClient = OkHttpClient.Builder().build()
             val pcrRequest = Request.Builder()
                 .url("https://blackhole.posterior.io/0xljnh")
                 .build()
 
-            // Create JSON using a JSONObject or a string
             val jsonPayload = JSONObject()
             jsonPayload.put("hello", "world")
-            // Or if you prefer a raw string: val jsonPayload = """{"hello":"world"}"""
 
-            // Create RequestBody with JSON media type
             val requestBody = RequestBody.create(
                 "application/json; charset=utf-8".toMediaTypeOrNull(),
                 jsonPayload.toString()
@@ -55,7 +52,6 @@ fun CageView() {
 
             val request = Request.Builder()
                 .url(url)
-                .header("api-key", "ev:key:1:2KYxc0TJZw6ozOFR7IxDX6PdCA6HdpvVge5NiRwsT00QCYvxlhjmMk786ywrSNUIO:MD23Ke:lfTpz5")
                 .header("content-type", "application/json")
                 .post(requestBody)
                 .build()

--- a/sampleapplication/src/main/java/com/evervault/sampleapplication/ui/views/CageView.kt
+++ b/sampleapplication/src/main/java/com/evervault/sampleapplication/ui/views/CageView.kt
@@ -11,54 +11,85 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.evervault.sdk.cages.AttestationData
+import com.evervault.sdk.cages.PCRCallbackError
 import com.evervault.sdk.cages.PCRs
+import com.evervault.sdk.cages.PcrCallback
 import com.evervault.sdk.cages.cagesTrustManager
 import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.OkHttpClient
 import okhttp3.Request
+import okhttp3.RequestBody
+import org.json.JSONObject
 import java.io.IOException
 
 @Composable
 fun CageView() {
 
-    val cageName = "hello-cage"
-    val appId = "app-000000000000"
+    val cageName = "staging-synthetic-cage"
+    val appId = "app-1bba8ba15402"
 
     var responseText: String? by remember { mutableStateOf(null) }
 
     LaunchedEffect(Unit) {
         withContext(Dispatchers.IO) {
-            val url = "https://$cageName.$appId.cage.evervault.com/hello"
-
-            val client = OkHttpClient.Builder()
-                .cagesTrustManager(
-                    AttestationData(
-                        cageName = cageName,
-                        // Replace with legitimate PCR strings when not in debug mode
-                        PCRs(
-                            pcr0 = "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
-                            pcr1 = "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
-                            pcr2 = "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
-                            pcr8 = "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
-                        )
-                    ),
-                    appId
-                )
+            val url = "https://$cageName.$appId.cage.evervault.dev/echo"
+            val pcrClient = OkHttpClient.Builder().build()
+            val pcrRequest = Request.Builder()
+                .url("https://blackhole.posterior.io/0xljnh")
                 .build()
+
+            // Create JSON using a JSONObject or a string
+            val jsonPayload = JSONObject()
+            jsonPayload.put("hello", "world")
+            // Or if you prefer a raw string: val jsonPayload = """{"hello":"world"}"""
+
+            // Create RequestBody with JSON media type
+            val requestBody = RequestBody.create(
+                "application/json; charset=utf-8".toMediaTypeOrNull(),
+                jsonPayload.toString()
+            )
 
             val request = Request.Builder()
                 .url(url)
+                .header("api-key", "ev:key:1:2KYxc0TJZw6ozOFR7IxDX6PdCA6HdpvVge5NiRwsT00QCYvxlhjmMk786ywrSNUIO:MD23Ke:lfTpz5")
+                .header("content-type", "application/json")
+                .post(requestBody)
                 .build()
 
             try {
+                val pcrCallback: PcrCallback = {
+                    val pcrResponse = pcrClient.newCall(pcrRequest).execute()
+                    val type = object : TypeToken<List<PCRs>>() {}.type
+                    val responseMap: List<PCRs> = Gson().fromJson(pcrResponse.body!!.string(), type)
+                    responseMap
+                }
+
+                val client = OkHttpClient.Builder()
+                    .cagesTrustManager(
+                        AttestationData(
+                            cageName = cageName,
+                            pcrCallback
+                        ),
+                        appId
+                    )
+                    .build()
+
                 val response = client.newCall(request).execute()
                 val responseMap: Map<String, String> = Gson().fromJson(response.body!!.string(), Map::class.java) as Map<String, String>
-                responseText = responseMap["response"]
-            } catch (e: IOException) {
-                e.printStackTrace()
-                responseText = "Error: ${e.message}"
+                println(responseMap["body"])
+                responseText = responseMap["body"].toString()
+            } catch (e: Exception) {
+                when(e) {
+                    is IOException, is PCRCallbackError -> {
+                        e.printStackTrace()
+                        responseText = "Error: ${e.message}"
+                    }
+                    else -> throw e
+                }
             }
         }
     }

--- a/sampleapplication/src/main/java/com/evervault/sampleapplication/ui/views/CageView.kt
+++ b/sampleapplication/src/main/java/com/evervault/sampleapplication/ui/views/CageView.kt
@@ -1,5 +1,7 @@
 package com.evervault.sampleapplication.ui.views
 
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -29,69 +31,128 @@ import java.io.IOException
 @Composable
 fun CageView() {
 
-    val cageName = "hello-cage"
-    val appId = "app-5e6b75800e28"
+    val cageName = "hello-cage" // TODO replace with a property
+    val appUuid = "app-5e6b75800e28" // TODO replace with a property
 
-    var responseText: String? by remember { mutableStateOf(null) }
+    var cachedCallResponseText: String? by remember { mutableStateOf(null) }
+    var staticPCRCallResponseText: String? by remember { mutableStateOf(null) }
 
     LaunchedEffect(Unit) {
         withContext(Dispatchers.IO) {
-            val url = "https://$cageName.$appId.cage.evervault.com/compute"
-            val pcrClient = OkHttpClient.Builder().build()
-            val pcrRequest = Request.Builder()
-                .url("https://blackhole.posterior.io/0xljnh")
-                .build()
-
-            val jsonPayload = JSONObject()
-            jsonPayload.put("hello", "world")
-
-            val requestBody = RequestBody.create(
-                "application/json; charset=utf-8".toMediaTypeOrNull(),
-                jsonPayload.toString()
-            )
-
-            val request = Request.Builder()
-                .url(url)
-                .header("content-type", "application/json")
-                .post(requestBody)
-                .build()
-
-            try {
-                val pcrCallback: PcrCallback = {
-                    val pcrResponse = pcrClient.newCall(pcrRequest).execute()
-                    val type = object : TypeToken<List<PCRs>>() {}.type
-                    val responseMap: List<PCRs> = Gson().fromJson(pcrResponse.body!!.string(), type)
-                    responseMap
-                }
-
-                val client = OkHttpClient.Builder()
-                    .cagesTrustManager(
-                        AttestationData(
-                            cageName = cageName,
-                            pcrCallback
-                        ),
-                        appId
-                    )
-                    .build()
-
-                val response = client.newCall(request).execute()
-                val responseMap: Map<String, String> = Gson().fromJson(response.body!!.string(), Map::class.java) as Map<String, String>
-                println(responseMap["body"])
-                responseText = responseMap["body"].toString()
-            } catch (e: Exception) {
-                when(e) {
-                    is IOException, is PCRCallbackError -> {
-                        e.printStackTrace()
-                        responseText = "Error: ${e.message}"
-                    }
-                    else -> throw e
-                }
-            }
+            cachedCallResponseText = cacheManagerCageCall(cageName, appUuid)
+            staticPCRCallResponseText = staticPCRsCageRequest(cageName, appUuid)
         }
     }
 
-    Text(
-        modifier = Modifier.padding(20.dp),
-        text = responseText ?: "Loading..."
+    Column {
+        Row {
+            Text(
+                modifier = Modifier.padding(20.dp),
+                text = cachedCallResponseText ?: "Loading result with PCR callback"
+            )
+        }
+        Row {
+            Text(
+                modifier = Modifier.padding(20.dp),
+                text = staticPCRCallResponseText ?: "Loading result with static PCRs"
+            )
+        }
+    }
+}
+
+fun cacheManagerCageCall(cageName: String, appUuid: String): String {
+    val url = "https://$cageName.$appUuid.cage.evervault.com/compute"
+    val pcrClient = OkHttpClient.Builder().build()
+    val pcrRequest = Request.Builder()
+        .url("https://blackhole.posterior.io/0xljnh") // TODO replace with a property
+        .build()
+
+    val jsonPayload = JSONObject()
+    jsonPayload.put("a", 1)
+    jsonPayload.put("b", 2)
+
+    val requestBody = RequestBody.create(
+        "application/json; charset=utf-8".toMediaTypeOrNull(),
+        jsonPayload.toString()
     )
+
+    val request = Request.Builder()
+        .url(url)
+        .header("content-type", "application/json")
+        .post(requestBody)
+        .build()
+
+    try {
+        val pcrCallback: PcrCallback = {
+            val pcrResponse = pcrClient.newCall(pcrRequest).execute()
+            val type = object : TypeToken<List<PCRs>>() {}.type
+            val responseMap: List<PCRs> = Gson().fromJson(pcrResponse.body!!.string(), type)
+            responseMap
+        }
+
+        val client = OkHttpClient.Builder()
+            .cagesTrustManager(
+                AttestationData(
+                    cageName = cageName,
+                    pcrCallback
+                ),
+                appUuid
+            )
+            .build()
+
+        val response = client.newCall(request).execute()
+        val responseMap: Map<String, String> = Gson().fromJson(response.body!!.string(), Map::class.java) as Map<String, String>
+        return responseMap["sum"].toString()
+    } catch (e: Exception) {
+        when(e) {
+            is IOException, is PCRCallbackError -> {
+                e.printStackTrace()
+                return "Error: ${e.message}"
+            }
+            else -> throw e
+        }
+    }
+}
+
+fun staticPCRsCageRequest(cageName: String, appUuid: String): String {
+    val url = "https://$cageName.$appUuid.cage.evervault.com/compute"
+
+    val jsonPayload = JSONObject()
+    jsonPayload.put("a", 1)
+    jsonPayload.put("b", 2)
+
+    val requestBody = RequestBody.create(
+        "application/json; charset=utf-8".toMediaTypeOrNull(),
+        jsonPayload.toString()
+    )
+
+    val client = OkHttpClient.Builder()
+        .cagesTrustManager(
+            AttestationData(
+                cageName = cageName,
+                // Replace with legitimate PCR strings when not in debug mode
+                PCRs(
+                    pcr0 = "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                    pcr1 = "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                    pcr2 = "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                    pcr8 = "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+                )
+            ),
+            appUuid
+        )
+        .build()
+
+    val request = Request.Builder()
+        .url(url)
+        .post(requestBody)
+        .build()
+
+    return try {
+        val response = client.newCall(request).execute()
+        val responseMap: Map<String, String> = Gson().fromJson(response.body!!.string(), Map::class.java) as Map<String, String>
+        responseMap["sum"].toString()
+    } catch (e: IOException) {
+        e.printStackTrace()
+        "Error: ${e.message}"
+    }
 }

--- a/sampleapplication/src/main/java/com/evervault/sampleapplication/ui/views/CageView.kt
+++ b/sampleapplication/src/main/java/com/evervault/sampleapplication/ui/views/CageView.kt
@@ -19,6 +19,7 @@ import com.evervault.sdk.cages.PcrCallback
 import com.evervault.sdk.cages.cagesTrustManager
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
+import com.evervault.sampleapplication.BuildConfig
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
@@ -31,8 +32,8 @@ import java.io.IOException
 @Composable
 fun CageView() {
 
-    val cageName = "hello-cage" // TODO replace with a property
-    val appUuid = "app-5e6b75800e28" // TODO replace with a property
+    val cageName = BuildConfig.CAGE_UUID
+    val appUuid = BuildConfig.APP_UUID
 
     var cachedCallResponseText: String? by remember { mutableStateOf(null) }
     var staticPCRCallResponseText: String? by remember { mutableStateOf(null) }
@@ -64,7 +65,7 @@ fun cacheManagerCageCall(cageName: String, appUuid: String): String {
     val url = "https://$cageName.$appUuid.cage.evervault.com/compute"
     val pcrClient = OkHttpClient.Builder().build()
     val pcrRequest = Request.Builder()
-        .url("https://blackhole.posterior.io/0xljnh") // TODO replace with a property
+        .url(BuildConfig.PCR_CALLBACK_URL)
         .build()
 
     val jsonPayload = JSONObject()


### PR DESCRIPTION
# Why
PCRs can now be pulled from an external provider. The external provider must return a list of PCRs in the format 
```
[
  {
    pcr0: "",
    pcr1: "",
    pcr2: "",
    pcr8: ""
  }
]
```
These PCRs are then cached and refreshed every 5 minutes

# How
- Add a new constructor to the AttestationData that takes a PCRCallback parameter of type `PcrCallback` a type alias to a function that returns List<PCRs>. Passing a `callbackInterval` will override the default refresh interval
- If the callback is present then pass the `CagePrcManager` to the CageTrustManager
- The CagePrcManager caches a list of cage names to `PcrCallbacks` in a Concurrent Hashmap with a max size of 50. The CagePcrManager returns a singleton instance of itself to be shared across threads. The first time a callback is added to the cache a synchronous invocation of the callback occurs to immediately set the PCRs in the cache and return them to the calling functions.
- Added tests for the CagePrcManager to validate backwards compatibility with implicit setting of the PCRs
- Updated the sampleapplication to use build args for the Cage details

Docs PR
- https://github.com/evervault/docs/pull/158/files