### PR TITLE
Eoin/etr 1428 inputs on android does not allow changing cursor colour

### DIFF
--- a/.changeset/pink-games-pay.md
+++ b/.changeset/pink-games-pay.md
@@ -1,0 +1,5 @@
+---
+"evervault-android": minor
+---
+
+This release allows for the setting of the cursor color for all input fields

--- a/evervault-inputs/build.gradle.kts
+++ b/evervault-inputs/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
 android {
     group = "com.evervault.sdk"
     namespace = "com.evervault.sdk.inputs"
-    compileSdk = 34
+    compileSdk = 33
     val prop = Properties().apply {
         load(FileInputStream(File(rootProject.rootDir, "version.properties")))
     }

--- a/evervault-inputs/build.gradle.kts
+++ b/evervault-inputs/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
 android {
     group = "com.evervault.sdk"
     namespace = "com.evervault.sdk.inputs"
-    compileSdk = 33
+    compileSdk = 34
     val prop = Properties().apply {
         load(FileInputStream(File(rootProject.rootDir, "version.properties")))
     }

--- a/evervault-inputs/src/main/java/com/evervault/sdk/input/ui/PaymentCardInputScope.kt
+++ b/evervault-inputs/src/main/java/com/evervault/sdk/input/ui/PaymentCardInputScope.kt
@@ -3,6 +3,7 @@ package com.evervault.sdk.input.ui
 import androidx.compose.material3.TextFieldColors
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.text.TextStyle
 
 interface PaymentCardInputScope {
@@ -35,7 +36,17 @@ interface PaymentCardInputScope {
         label: @Composable() (() -> Unit)?,
         placeholder: @Composable() (() -> Unit)?,
         textStyle: TextStyle,
-        textFieldColors: TextFieldColors
+        textFieldColors: TextFieldColors,
+    )
+
+    @Composable
+    fun CardNumberField(
+        modifier: Modifier,
+        label: @Composable() (() -> Unit)?,
+        placeholder: @Composable() (() -> Unit)?,
+        textStyle: TextStyle,
+        textFieldColors: TextFieldColors,
+        cursorBrush: Brush?,
     )
 
     @Composable
@@ -56,7 +67,17 @@ interface PaymentCardInputScope {
         label: @Composable() (() -> Unit)?,
         placeholder: @Composable() (() -> Unit)?,
         textStyle: TextStyle,
-        textFieldColors: TextFieldColors
+        textFieldColors: TextFieldColors,
+    )
+
+    @Composable
+    fun ExpiryField(
+        modifier: Modifier,
+        label: @Composable() (() -> Unit)?,
+        placeholder: @Composable() (() -> Unit)?,
+        textStyle: TextStyle,
+        textFieldColors: TextFieldColors,
+        cursorBrush: Brush?,
     )
 
     @Composable
@@ -77,6 +98,16 @@ interface PaymentCardInputScope {
         label: @Composable() (() -> Unit)?,
         placeholder: @Composable() (() -> Unit)?,
         textStyle: TextStyle,
-        textFieldColors: TextFieldColors
+        textFieldColors: TextFieldColors,
+    )
+
+    @Composable
+    fun CVCField(
+        modifier: Modifier,
+        label: @Composable() (() -> Unit)?,
+        placeholder: @Composable() (() -> Unit)?,
+        textStyle: TextStyle,
+        textFieldColors: TextFieldColors,
+        cursorBrush: Brush?,
     )
 }

--- a/evervault-inputs/src/main/java/com/evervault/sdk/input/ui/PaymentCardInputScopeImpl.kt
+++ b/evervault-inputs/src/main/java/com/evervault/sdk/input/ui/PaymentCardInputScopeImpl.kt
@@ -1,6 +1,7 @@
 package com.evervault.sdk.input.ui
 
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.text.BasicTextField
@@ -20,7 +21,9 @@ import androidx.compose.ui.autofill.AutofillNode
 import androidx.compose.ui.autofill.AutofillType
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.platform.LocalAutofill
 import androidx.compose.ui.platform.LocalAutofillTree
 import androidx.compose.ui.res.painterResource
@@ -119,7 +122,30 @@ internal class PaymentCardInputScopeImpl(
             textStyle = textStyle,
             textFieldColors = textFieldColors,
             onNext = { expiryRequester.requestFocus() },
-            autofillType = AutofillType.CreditCardNumber
+            autofillType = AutofillType.CreditCardNumber,
+        )
+    }
+
+    @OptIn(ExperimentalComposeUiApi::class)
+    @Composable
+    override fun CardNumberField(
+        modifier: Modifier,
+        label: (@Composable () -> Unit)?,
+        placeholder: (@Composable () -> Unit)?,
+        textStyle: TextStyle,
+        textFieldColors: TextFieldColors,
+        cursorBrush: Brush?
+    ) {
+        CustomTextField(
+            state = creditCardNumber,
+            modifier = modifier.focusRequester(creditCardRequester),
+            label = label,
+            placeholder = placeholder,
+            textStyle = textStyle,
+            textFieldColors = textFieldColors,
+            onNext = { expiryRequester.requestFocus() },
+            autofillType = AutofillType.CreditCardNumber,
+            cursorBrush = cursorBrush
         )
     }
 
@@ -176,7 +202,30 @@ internal class PaymentCardInputScopeImpl(
             textStyle = textStyle,
             textFieldColors = textFieldColors,
             onNext = { cvcRequester.requestFocus() },
-            autofillType = AutofillType.CreditCardExpirationDate
+            autofillType = AutofillType.CreditCardExpirationDate,
+        )
+    }
+
+    @OptIn(ExperimentalComposeUiApi::class)
+    @Composable
+    override fun ExpiryField(
+        modifier: Modifier,
+        label: (@Composable () -> Unit)?,
+        placeholder: (@Composable () -> Unit)?,
+        textStyle: TextStyle,
+        textFieldColors: TextFieldColors,
+        cursorBrush: Brush?,
+    ) {
+        CustomTextField(
+            state = expiryDate,
+            modifier = modifier.focusRequester(expiryRequester),
+            label = label,
+            placeholder = placeholder,
+            textStyle = textStyle,
+            textFieldColors = textFieldColors,
+            onNext = { cvcRequester.requestFocus() },
+            autofillType = AutofillType.CreditCardExpirationDate,
+            cursorBrush = cursorBrush,
         )
     }
 
@@ -233,7 +282,29 @@ internal class PaymentCardInputScopeImpl(
             placeholder = placeholder,
             textStyle = textStyle,
             textFieldColors = textFieldColors,
-            autofillType = AutofillType.CreditCardSecurityCode
+            autofillType = AutofillType.CreditCardSecurityCode,
+        )
+    }
+
+    @OptIn(ExperimentalComposeUiApi::class)
+    @Composable
+    override fun CVCField(
+        modifier: Modifier,
+        label: (@Composable () -> Unit)?,
+        placeholder: (@Composable () -> Unit)?,
+        textStyle: TextStyle,
+        textFieldColors: TextFieldColors,
+        cursorBrush: Brush?,
+    ) {
+        CustomTextField(
+            state = cvc,
+            modifier = modifier.focusRequester(cvcRequester),
+            label = label,
+            placeholder = placeholder,
+            textStyle = textStyle,
+            textFieldColors = textFieldColors,
+            autofillType = AutofillType.CreditCardSecurityCode,
+            cursorBrush = cursorBrush
         )
     }
 
@@ -245,7 +316,7 @@ internal class PaymentCardInputScopeImpl(
         modifier: Modifier = Modifier,
         options: PaymentCardInputScope.TextFieldOptions,
         onNext: (() -> Unit)? = null,
-        autofillType: AutofillType
+        autofillType: AutofillType,
     ) {
         val autofill = LocalAutofill.current
         val autofillNode = AutofillNode(
@@ -270,6 +341,7 @@ internal class PaymentCardInputScopeImpl(
             keyboardActions = KeyboardActions(
                 onNext = { onNext?.invoke() },
             ),
+            cursorBrush = setDefaultCursorBrush(),
             decorationBox = @Composable { innerTextField ->
                 TextFieldDefaults.DecorationBox(
                     value = state.value.text,
@@ -295,5 +367,14 @@ internal class PaymentCardInputScopeImpl(
                 )
             }
         )
+    }
+
+    @Composable
+    private fun setDefaultCursorBrush(): Brush {
+        return if(isSystemInDarkTheme()) {
+            SolidColor(Color.White)
+        } else {
+            SolidColor(Color.Black)
+        }
     }
 }

--- a/evervault-inputs/src/main/java/com/evervault/sdk/input/ui/component/CustomTextField.kt
+++ b/evervault-inputs/src/main/java/com/evervault/sdk/input/ui/component/CustomTextField.kt
@@ -1,6 +1,7 @@
 package com.evervault.sdk.input.ui.component
 
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
@@ -16,6 +17,9 @@ import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.autofill.AutofillNode
 import androidx.compose.ui.autofill.AutofillType
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.platform.LocalAutofill
 import androidx.compose.ui.platform.LocalAutofillTree
 import androidx.compose.ui.text.TextStyle
@@ -41,7 +45,8 @@ internal fun CustomTextField(
     textStyle: TextStyle = LocalTextStyle.current,
     textFieldColors: TextFieldColors = TextFieldDefaults.colors(),
     onNext: (() -> Unit)? = null,
-    autofillType: AutofillType
+    autofillType: AutofillType,
+    cursorBrush: Brush = setDefaultCursorBrush()
 ) {
     val interactionSource = remember { MutableInteractionSource() }
     val autofill = LocalAutofill.current
@@ -50,7 +55,6 @@ internal fun CustomTextField(
         onFill = { state.value = TextFieldValue(it) }
     )
     LocalAutofillTree.current.plusAssign(autofillNode)
-
 
     BasicTextField(
         value = state.value,
@@ -69,6 +73,7 @@ internal fun CustomTextField(
         keyboardActions = KeyboardActions(
             onNext = { onNext?.invoke() },
         ),
+        cursorBrush = cursorBrush,
         decorationBox = @Composable { innerTextField ->
             TextFieldDefaults.DecorationBox(
                 value = state.value.text,
@@ -84,5 +89,12 @@ internal fun CustomTextField(
             )
         }
     )
+}
 
+@Composable
+private fun setDefaultCursorBrush(): Brush {
+    if(isSystemInDarkTheme()) {
+        return SolidColor(Color.White)
+    }
+    return SolidColor(Color.Black)
 }

--- a/evervault-inputs/src/main/java/com/evervault/sdk/input/ui/component/CustomTextField.kt
+++ b/evervault-inputs/src/main/java/com/evervault/sdk/input/ui/component/CustomTextField.kt
@@ -46,7 +46,7 @@ internal fun CustomTextField(
     textFieldColors: TextFieldColors = TextFieldDefaults.colors(),
     onNext: (() -> Unit)? = null,
     autofillType: AutofillType,
-    cursorBrush: Brush = setDefaultCursorBrush()
+    cursorBrush: Brush? = null
 ) {
     val interactionSource = remember { MutableInteractionSource() }
     val autofill = LocalAutofill.current
@@ -55,7 +55,7 @@ internal fun CustomTextField(
         onFill = { state.value = TextFieldValue(it) }
     )
     LocalAutofillTree.current.plusAssign(autofillNode)
-
+    val defaultOrPassedBrush = setDefaultCursorBrush(cursorBrush)
     BasicTextField(
         value = state.value,
         onValueChange = { state.value = it },
@@ -73,7 +73,7 @@ internal fun CustomTextField(
         keyboardActions = KeyboardActions(
             onNext = { onNext?.invoke() },
         ),
-        cursorBrush = cursorBrush,
+        cursorBrush = defaultOrPassedBrush,
         decorationBox = @Composable { innerTextField ->
             TextFieldDefaults.DecorationBox(
                 value = state.value.text,
@@ -92,9 +92,11 @@ internal fun CustomTextField(
 }
 
 @Composable
-private fun setDefaultCursorBrush(): Brush {
-    if(isSystemInDarkTheme()) {
-        return SolidColor(Color.White)
+private fun setDefaultCursorBrush(cursorBrush: Brush?): Brush {
+    cursorBrush?.let { return it }
+    return if(isSystemInDarkTheme()) {
+        SolidColor(Color.White)
+    } else {
+        SolidColor(Color.Black)
     }
-    return SolidColor(Color.Black)
 }

--- a/evervault-inputs/src/main/java/com/evervault/sdk/input/ui/sample/PaymentCardSamples.kt
+++ b/evervault-inputs/src/main/java/com/evervault/sdk/input/ui/sample/PaymentCardSamples.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -163,7 +164,7 @@ internal fun PaymentCardWithCustomizedLayoutSample() {
                     )
                 },
                 textStyle = MaterialTheme.typography.bodySmall,
-                textFieldColors = TextFieldDefaults.colors()
+                textFieldColors = TextFieldDefaults.colors(),
             )
 
             ExpiryField(


### PR DESCRIPTION
# Why
When dark mode is set as the system theme the cursor remains black, so a user cannot see it. 
# How
The assumption was made that setting the cursor color in `TextFieldDefaults` that are passed to the `DecorationBox` would allow a user to of inputs to set the cursor color based on their theme. However `BasicTextField` isn't compatible with this. You need to set the `cursorBrush` property. 

By default if the cursor color will invert between black and white if dark mode is on. If another color is needed you can now pass a `Brush` to the fields composable components. 

This fixes issue #50 