### PR TITLE
feat: remove duplicate dependancy from android

### DIFF
--- a/.changeset/shiny-ears-collect.md
+++ b/.changeset/shiny-ears-collect.md
@@ -1,0 +1,5 @@
+---
+"evervault-android": patch
+---
+
+Remove duplicate dependency

--- a/evervault-enclaves/build.gradle.kts
+++ b/evervault-enclaves/build.gradle.kts
@@ -67,7 +67,6 @@ dependencies {
     implementation("androidx.activity:activity-compose:1.5.1")
     implementation("net.java.dev.jna:jna:5.7.0@aar")
     implementation("com.squareup.okhttp3:okhttp:4.11.0")
-    implementation("junit:junit:4.12")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.3.2")
     implementation("com.squareup.okhttp3:okhttp:4.9.3")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.2")


### PR DESCRIPTION
# Why
Looks like junit was accidentally included as a production dependency. 

# How
- Remove duplicate dependency