### PR TITLE
Dont use main thread for storing attestation doc

### DIFF
--- a/.changeset/lovely-poems-wonder.md
+++ b/.changeset/lovely-poems-wonder.md
@@ -1,0 +1,5 @@
+---
+"evervault-android": patch
+---
+
+Removing attestation doc request on the main thread during initialisation

--- a/evervault-cages/src/main/java/com/evervault/sdk/cages/AttestationDocCache.kt
+++ b/evervault-cages/src/main/java/com/evervault/sdk/cages/AttestationDocCache.kt
@@ -24,10 +24,10 @@ class AttestationDocCache(private val cageName: String, private val appUuid: Str
     private val lock = ReentrantReadWriteLock()
 
     init {
-        storeDoc(2)
         GlobalScope.launch(Dispatchers.IO) {
+            storeDoc(2)
             poll(300)
-        }
+        }   
     }
 
     private fun storeDoc(retries: Int) {

--- a/evervault-enclaves/src/main/java/com/evervault/sdk/enclaves/AttestationDocCache.kt
+++ b/evervault-enclaves/src/main/java/com/evervault/sdk/enclaves/AttestationDocCache.kt
@@ -23,8 +23,8 @@ class AttestationDocCache(private val enclaveName: String, private val appUuid: 
     private val lock = ReentrantReadWriteLock()
 
     init {
-        storeDoc(2)
         GlobalScope.launch(Dispatchers.IO) {
+            storeDoc(2)
             poll(300)
         }
     }
@@ -33,7 +33,7 @@ class AttestationDocCache(private val enclaveName: String, private val appUuid: 
         if(retries >= 0) {
             try {
                 val url =
-                    "https://${enclaveName}.${appUuid}.cage.evervault.com/.well-known/attestation"
+                    "https://${enclaveName}.${appUuid}.enclave.evervault.com/.well-known/attestation"
                 val response = getDocFromEnclave(url)
                 val decodedDoc = Base64.decode(response.attestationDoc, Base64.DEFAULT)
                 set(decodedDoc)


### PR DESCRIPTION
# Why
We shouldn't be requesting the attestation doc on the main thread during initialisation

# How
Move store doc call, `get` will pull in an attestation doc if the cache is empty so this is safe
update enclave domain