### PR TITLE
fix: concant fields from autofill result

### DIFF
--- a/.changeset/violet-olives-unite.md
+++ b/.changeset/violet-olives-unite.md
@@ -1,0 +1,5 @@
+---
+"evervault-android": patch
+---
+
+Fix 1Password autofil

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: test
 
-on: [ push, pull_request ]
+on: [push, pull_request]
 
 env:
   CARGO_TERM_COLOR: always
@@ -12,13 +12,13 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v3
         with:
-          distribution: 'corretto'
-          java-version: '17'
+          distribution: "corretto"
+          java-version: "17"
       - name: build and test project
         run: ./gradlew clean build --info
       - name: Upload unit test report on failure
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: failed_unit_tests
           path: ${{ github.workspace }}/lib/build/reports/tests/test
@@ -28,8 +28,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v3
         with:
-          distribution: 'corretto'
-          java-version: '17'
+          distribution: "corretto"
+          java-version: "17"
       - name: e2e tests
         env:
           EV_API_KEY: ${{ secrets.EV_API_KEY }}
@@ -38,7 +38,7 @@ jobs:
         run: ./gradlew clean :evervault-common-e2e:build --info
       - name: Upload unit test report on failure
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: failed_unit_tests
           path: ${{ github.workspace }}/lib/build/reports/tests/test

--- a/evervault-inputs/src/main/java/com/evervault/sdk/input/ui/PaymentCardInputScopeImpl.kt
+++ b/evervault-inputs/src/main/java/com/evervault/sdk/input/ui/PaymentCardInputScopeImpl.kt
@@ -321,7 +321,9 @@ internal class PaymentCardInputScopeImpl(
         val autofill = LocalAutofill.current
         val autofillNode = AutofillNode(
             autofillTypes = listOf(autofillType),
-            onFill = { state.value = TextFieldValue(it) }
+            onFill = {
+                state.value = TextFieldValue(state.value.text + it)
+            }
         )
         LocalAutofillTree.current.plusAssign(autofillNode)
 

--- a/evervault-inputs/src/main/java/com/evervault/sdk/input/ui/component/CustomTextField.kt
+++ b/evervault-inputs/src/main/java/com/evervault/sdk/input/ui/component/CustomTextField.kt
@@ -52,7 +52,9 @@ internal fun CustomTextField(
     val autofill = LocalAutofill.current
     val autofillNode = AutofillNode(
         autofillTypes = listOf(autofillType),
-        onFill = { state.value = TextFieldValue(it) }
+        onFill = {
+            state.value = TextFieldValue(state.value.text + it)
+        }
     )
     LocalAutofillTree.current.plusAssign(autofillNode)
     val defaultOrPassedBrush = setDefaultCursorBrush(cursorBrush)


### PR DESCRIPTION
# Why
The 1Password autofill provider does not work with inputs. The 1Password autofill service is sending the values back split on the space character. Unlike google wallet which will send a card as a complete number.
# How
- When in focus concatenate the values into the existing state