### PR TITLE
Read secrets from local properties

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
               }
             ' CHANGELOG.md)
             gh release create $COMMIT_TAG -t "$COMMIT_TAG" -n "$CHANGELOG"
-            ./generate_gradle_properties.bash ${{ github.workspace }}
+            ./generate_local_properties.bash ${{ github.workspace }}
             ./gradlew publishToSonatype
           else
             echo "No tag attached to HEAD. No new release needed."

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,6 +8,14 @@ buildscript {
         classpath("com.android.tools.build:gradle:7.4.2")
     }
 }
+
+// Load properties from local.properties
+val localProperties = java.util.Properties()
+val localPropertiesFile = rootProject.file("local.properties")
+if (localPropertiesFile.exists()) {
+    localProperties.load(java.io.FileInputStream(localPropertiesFile))
+}
+
 group "com.evervault.sdk"
 plugins {
     kotlin("jvm") version "1.8.21" apply false
@@ -27,8 +35,8 @@ allprojects {
     }
 }
 
-val ossrhUsername: String? by project
-val ossrhPassword: String? by project
+val ossrhUsername: String? = localProperties.getProperty("ossrhUsername")
+val ossrhPassword: String? = localProperties.getProperty("ossrhPassword")
 
 nexusPublishing {
     repositories {

--- a/evervault-cages/build.gradle.kts
+++ b/evervault-cages/build.gradle.kts
@@ -121,8 +121,15 @@ publishing {
 }
 
 signing {
-    val signingKey: String? by project
-    val signingPassword: String? by project
+    // Load properties from local.properties
+    val localProperties = Properties()
+    val localPropertiesFile = rootProject.file("local.properties")
+    if (localPropertiesFile.exists()) {
+        localProperties.load(FileInputStream(localPropertiesFile))
+    }
+    
+    val signingKey: String? = localProperties.getProperty("signingKey")
+    val signingPassword: String? = localProperties.getProperty("signingPassword")
     useInMemoryPgpKeys(signingKey ?: "", signingPassword ?: "")
 
     sign(publishing.publications["release"])

--- a/evervault-enclaves/build.gradle.kts
+++ b/evervault-enclaves/build.gradle.kts
@@ -125,8 +125,15 @@ publishing {
 }
 
 signing {
-    val signingKey: String? by project
-    val signingPassword: String? by project
+    // Load properties from local.properties
+    val localProperties = Properties()
+    val localPropertiesFile = rootProject.file("local.properties")
+    if (localPropertiesFile.exists()) {
+        localProperties.load(FileInputStream(localPropertiesFile))
+    }
+    
+    val signingKey: String? = localProperties.getProperty("signingKey")
+    val signingPassword: String? = localProperties.getProperty("signingPassword")
     useInMemoryPgpKeys(signingKey ?: "", signingPassword ?: "")
 
     sign(publishing.publications["release"])

--- a/evervault-inputs/build.gradle.kts
+++ b/evervault-inputs/build.gradle.kts
@@ -121,8 +121,15 @@ publishing {
 }
 
 signing {
-    val signingKey: String? by project
-    val signingPassword: String? by project
+    // Load properties from local.properties
+    val localProperties = Properties()
+    val localPropertiesFile = rootProject.file("local.properties")
+    if (localPropertiesFile.exists()) {
+        localProperties.load(FileInputStream(localPropertiesFile))
+    }
+    
+    val signingKey: String? = localProperties.getProperty("signingKey")
+    val signingPassword: String? = localProperties.getProperty("signingPassword")
     useInMemoryPgpKeys(signingKey ?: "", signingPassword ?: "")
 
     sign(publishing.publications["release"])

--- a/generate_gradle_properties.bash
+++ b/generate_gradle_properties.bash
@@ -1,6 +1,0 @@
-set -e
-
-echo "signingKey=${GPG_KEY_FILE}" >> ${1}/gradle.properties
-echo "signingPassword=${GPG_KEY_PASSWORD}" >> ${1}/gradle.properties
-echo "ossrhUsername=${SONATYPE_USERNAME}" >> ${1}/gradle.properties
-echo "ossrhPassword=${SONATYPE_PASSWORD}" >> ${1}/gradle.properties

--- a/generate_local_properties.bash
+++ b/generate_local_properties.bash
@@ -1,0 +1,6 @@
+set -e
+
+echo "signingKey=${GPG_KEY_FILE}" >> ${1}/local.properties
+echo "signingPassword=${GPG_KEY_PASSWORD}" >> ${1}/local.properties
+echo "ossrhUsername=${SONATYPE_USERNAME}" >> ${1}/local.properties
+echo "ossrhPassword=${SONATYPE_PASSWORD}" >> ${1}/local.properties


### PR DESCRIPTION
# Why
Read in publishing secrets from a gitignored file (`local.properties`) to minimize the risk that secrets get pushed to Github accidentally.

# How
Describe how you've approached the problem