### PR TITLE
Add Product Engineering team as code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,6 @@
-@boilsquid
+# This file is used to automatically request reviews on PRs.
+
+# These owners will be the default owners for everything in
+# the repo, unless a match on a later line takes precedence.
+# "@evervault/product-engineering" below requests review from all members of Product Engineering.
+*       @evervault/product-engineering


### PR DESCRIPTION
Updated CODEOWNERS file to include Product Engineering team.

# Why
Add a short description about this PR.
Add links to issues, tech plans etc.

# How
Describe how you've approached the problem